### PR TITLE
feat(nft-apis): added support for NFT APIs

### DIFF
--- a/pkg/constants/chain.go
+++ b/pkg/constants/chain.go
@@ -26,12 +26,18 @@ const (
 	TS_GetTokenList           APIName = "v1/tokenstore/token/all"
 	TS_GetTokenWithSymbol     APIName = "v1/tokenstore/token/symbol/:symbol"
 	Assets_GetAssets          APIName = "v1/:chain/address/:address/assets"
+	NFT_GetAssets             APIName = "v1/:chain/address/:address/nft-assets"
+	NFT_GetTxns               APIName = "v1/:chain/address/:address/nft-transactions"
+	NFT_GetDetailsWithID      APIName = "v1/:chain/address/:address/details"
+	NFT_GetHoldersByID        APIName = "v1/:chain/address/:address/nftholders"
 )
 
 //This should be manually changed when a new chain starts being supported
 var allChains = map[Chain]bool{ETH: true, BSC: true, MATIC: true, XDC: true, SOL: true, ZILLIQA: true, HUOBI: true}
 
 var priceStoreSupported = map[Chain]bool{ETH: true, BSC: true, MATIC: true}
+
+var nftEVMSupport = map[Chain]bool{ETH: true, BSC: true, MATIC: true}
 
 var allowedCallersByAPI = map[APIName]map[Chain]bool{
 	PS_GetPriceWithAddress: priceStoreSupported,
@@ -40,6 +46,10 @@ var allowedCallersByAPI = map[APIName]map[Chain]bool{
 	PS_GetLosers:           priceStoreSupported,
 	PS_GetGainers:          priceStoreSupported,
 	Assets_GetAssets:       allChains,
+	NFT_GetAssets:          {ETH: true, BSC: true, MATIC: true, SOL: true},
+	NFT_GetTxns:            nftEVMSupport,
+	NFT_GetDetailsWithID:   nftEVMSupport,
+	NFT_GetHoldersByID:     nftEVMSupport,
 }
 
 //String returns the string specific version of the chain

--- a/pkg/nft_details/nft_details.go
+++ b/pkg/nft_details/nft_details.go
@@ -1,0 +1,13 @@
+package nft_details
+
+import (
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/constants"
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/nft_details/types"
+)
+
+type NftDetails interface {
+	GetAssetsByAddress(chain constants.Chain, address string) (response types.NFTAssetsResp, err error)
+	GetTransactionsByAddress(chain constants.Chain, address string, pageNumber int, pageSize int) (response types.NFTTxnsResp, err error)
+	GetDetailsByID(chain constants.Chain, tokenID string, NFTAddress string) (response types.NFTByTokenIDResp, err error)
+	GetHolderByID(chain constants.Chain, tokenID string, NFTAddress string) (response types.NFTHolderResponse, err error)
+}

--- a/pkg/nft_details/nft_details_impl.go
+++ b/pkg/nft_details/nft_details_impl.go
@@ -1,0 +1,79 @@
+package nft_details
+
+import (
+	"fmt"
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/constants"
+	httpclient "github.com/eucrypt/unmarshal-go-sdk/pkg/http"
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/nft_details/types"
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/session"
+	"strings"
+)
+
+type NFTDetailsImpl struct {
+	sess session.Session
+}
+
+func New(sess session.Session) NFTDetailsImpl {
+	return NFTDetailsImpl{sess: sess}
+}
+
+func (nft NFTDetailsImpl) GetAssetsByAddress(chain constants.Chain, address string) (resp types.NFTAssetsResp, err error) {
+	if !constants.NFT_GetAssets.SupportsChain(chain) {
+		return types.NFTAssetsResp{}, constants.UnsupportedChainError
+	}
+	path := strings.Replace(constants.NFT_GetAssets.GetURI(), ":chain", chain.String(), 1)
+	path = strings.Replace(path, ":address", address, 1)
+	err = nft.sess.Client.Get(&resp, path, nil)
+
+	return
+}
+
+func (nft NFTDetailsImpl) GetTransactionsByAddress(chain constants.Chain, address string, pageNumber int, pageSize int) (
+	resp types.NFTTxnsResp, err error) {
+	if !constants.NFT_GetTxns.SupportsChain(chain) {
+		return types.NFTTxnsResp{}, constants.UnsupportedChainError
+	}
+	path := strings.Replace(constants.NFT_GetTxns.GetURI(), ":chain", chain.String(), 1)
+	path = strings.Replace(path, ":address", address, 1)
+	vals := map[string]interface{}{
+		"page":     fmt.Sprint(pageNumber),
+		"pageSize": fmt.Sprint(pageSize),
+	}
+	var urlVals = httpclient.QueryParamHelper(vals)
+	err = nft.sess.Client.Get(&resp, path, urlVals)
+
+	return
+}
+
+func (nft NFTDetailsImpl) GetDetailsByID(chain constants.Chain, tokenID string, NFTAddress string) (
+	resp types.NFTByTokenIDResp, err error) {
+
+	if !constants.NFT_GetDetailsWithID.SupportsChain(chain) {
+		return types.NFTByTokenIDResp{}, constants.UnsupportedChainError
+	}
+	path := strings.Replace(constants.NFT_GetDetailsWithID.GetURI(), ":chain", chain.String(), 1)
+	path = strings.Replace(path, ":address", NFTAddress, 1)
+	vals := map[string]interface{}{
+		"tokenId": tokenID,
+	}
+	var urlVals = httpclient.QueryParamHelper(vals)
+	err = nft.sess.Client.Get(&resp, path, urlVals)
+	return
+}
+
+func (nft NFTDetailsImpl) GetHolderByID(chain constants.Chain, tokenID string, NFTAddress string) (
+	resp types.NFTHolderResponse, err error) {
+
+	if !constants.NFT_GetHoldersByID.SupportsChain(chain) {
+		return types.NFTHolderResponse{}, constants.UnsupportedChainError
+	}
+	path := strings.Replace(constants.NFT_GetHoldersByID.GetURI(), ":chain", chain.String(), 1)
+	path = strings.Replace(path, ":address", NFTAddress, 1)
+	vals := map[string]interface{}{
+		"tokenId": tokenID,
+	}
+	var urlVals = httpclient.QueryParamHelper(vals)
+	err = nft.sess.Client.Get(&resp, path, urlVals)
+
+	return
+}

--- a/pkg/nft_details/nft_details_impl_test.go
+++ b/pkg/nft_details/nft_details_impl_test.go
@@ -1,0 +1,146 @@
+package nft_details
+
+import (
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/constants"
+	httpclient "github.com/eucrypt/unmarshal-go-sdk/pkg/http"
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/session"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestNFTDetailsImpl_GetAssetsByAddress(t *testing.T) {
+	nftObj := getTestNFTObj()
+	ast := assert.New(t)
+	t.Run("Evaluating Get Assets by Address", func(t *testing.T) {
+		validAddr := "demo.eth"
+		chain := constants.ETH
+
+		resp, err := nftObj.GetAssetsByAddress(chain, validAddr)
+
+		ast.NoError(err, "There should be no error for a valid call")
+		ast.NotEmpty(resp, "The response should not be empty")
+
+		resp, _ = nftObj.GetAssetsByAddress(chain, "")
+		ast.Empty(resp, "should have an empty response for an invalid call")
+
+		//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
+		_, err = nftObj.GetAssetsByAddress(constants.HUOBI, "")
+		ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
+
+	})
+}
+
+func getTestNFTObj() NFTDetailsImpl {
+	httpClient := httpclient.NewHttpJSONClient(constants.Environment.GetEndpoint("prod"))
+	authKey := os.Getenv("API_KEY")
+	httpClient.DefaultQuery = map[string]string{"auth_key": authKey}
+	NftImpl := New(session.Session{Config: struct {
+		AuthKey     string
+		HttpClient  *http.Client
+		Environment constants.Environment
+	}{AuthKey: authKey, HttpClient: nil, Environment: constants.Prod}, Client: httpClient})
+	return NftImpl
+}
+
+func TestNFTDetailsImpl_GetDetailsByID(t *testing.T) {
+	nftObj := getTestNFTObj()
+	ast := assert.New(t)
+
+	t.Run("Evaluating Get NFT Details by ID", func(t *testing.T) {
+		validChain := constants.ETH
+		validTokenId := "61"
+		validNFTAddr := "0x3cf8695c5cb6caa78d9c7fc9fa34bc8271483a1a"
+
+		resp, err := nftObj.GetDetailsByID(validChain, validTokenId, validNFTAddr)
+
+		ast.NoError(err, "There should be no error for a valid call")
+		ast.NotEmpty(resp, "The response should not be empty")
+
+		resp, _ = nftObj.GetDetailsByID(validChain, "", "")
+		ast.Empty(resp, "should have an empty response for an invalid call")
+
+		//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
+		_, err = nftObj.GetDetailsByID(constants.HUOBI, "", "")
+		ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
+	})
+	t.Run("Evaluating Get NFT Details by ID 2", func(t *testing.T) {
+		validChain := constants.ETH
+		validTokenId := "1300020038"
+		validNFTAddr := "0x4629122c04eacc2ca48bda4a92aadcaee5d15389"
+
+		resp, err := nftObj.GetDetailsByID(validChain, validTokenId, validNFTAddr)
+
+		ast.NoError(err, "There should be no error for a valid call")
+		ast.NotEmpty(resp, "The response should not be empty")
+
+	})
+}
+
+func TestNFTDetailsImpl_GetHolderByID(t *testing.T) {
+	nftObj := getTestNFTObj()
+	ast := assert.New(t)
+
+	t.Run("Evaluating Get NFT Holders by Token ID", func(t *testing.T) {
+		validChain := constants.ETH
+		validTokenId := "61"
+		validNFTAddr := "0x3cf8695c5cb6caa78d9c7fc9fa34bc8271483a1a"
+
+		resp, err := nftObj.GetHolderByID(validChain, validTokenId, validNFTAddr)
+
+		ast.NoError(err, "There should be no error for a valid call")
+		ast.NotEmpty(resp, "The response should not be empty")
+
+		resp, _ = nftObj.GetHolderByID(validChain, "", "")
+		ast.Empty(resp, "should have an empty response for an invalid call")
+
+		//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
+		_, err = nftObj.GetHolderByID(constants.HUOBI, "", "")
+		ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
+	})
+	t.Run("Evaluating Get NFT Holders by Token ID 2", func(t *testing.T) {
+		validChain := constants.ETH
+		validTokenId := "1300020038"
+		validNFTAddr := "0x4629122c04eacc2ca48bda4a92aadcaee5d15389"
+
+		resp, err := nftObj.GetHolderByID(validChain, validTokenId, validNFTAddr)
+
+		ast.NoError(err, "There should be no error for a valid call")
+		ast.NotEmpty(resp, "The response should not be empty")
+
+	})
+}
+
+func TestNFTDetailsImpl_GetTransactionsByAddress(t *testing.T) {
+	nftObj := getTestNFTObj()
+	ast := assert.New(t)
+
+	t.Run("Evaluating Get NFT Transactions By Address", func(t *testing.T) {
+		validAddr := "0x39fcb954d0535befe1b0f52aea79ca2ee1ddf54e"
+		validChain := constants.ETH
+		pageNumber := 1
+		pageSize := 5
+
+		resp, err := nftObj.GetTransactionsByAddress(validChain, validAddr, pageNumber, pageSize)
+		ast.NoError(err, "There should be no error for a valid call")
+		ast.NotEmpty(resp, "The response should not be empty")
+		ast.Len(resp, 5, "Exactly 5 objects should be a part of the response")
+
+		//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
+		_, err = nftObj.GetTransactionsByAddress(constants.HUOBI, "", 0, 0)
+		ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
+	})
+	t.Run("Evaluating Get NFT Transactions By Address 2", func(t *testing.T) {
+		validAddr := "demo.eth"
+		validChain := constants.ETH
+		pageNumber := 1
+		pageSize := 10
+
+		resp, err := nftObj.GetTransactionsByAddress(validChain, validAddr, pageNumber, pageSize)
+		ast.NoError(err, "There should be no error for a valid call")
+		ast.NotEmpty(resp, "The response should not be empty")
+		ast.Len(resp, 10, "Exactly 10 objects should be a part of the response")
+
+	})
+}

--- a/pkg/nft_details/types/types.go
+++ b/pkg/nft_details/types/types.go
@@ -1,0 +1,61 @@
+package types
+
+type NFTAsset struct {
+	AssetContract      string `json:"asset_contract"`
+	TokenId            string `json:"token_id"`
+	Owner              string `json:"owner"`
+	ExternalLink       string `json:"external_link"`
+	Type               string `json:"type"`
+	Balance            int    `json:"balance"`
+	IssuerSpecificData struct {
+		EntireResponse string `json:"entire_response"`
+		ImageUrl       string `json:"image_url"`
+		Name           string `json:"name"`
+	} `json:"issuer_specific_data"`
+	Price        string `json:"price"`
+	AnimationUrl string `json:"animation_url"`
+	Description  string `json:"description"`
+	NftMetadata  []struct {
+		TraitType   string      `json:"trait_type"`
+		Value       interface{} `json:"value"`
+		DisplayType string      `json:"display_type,omitempty"`
+	} `json:"nft_metadata,omitempty"`
+}
+
+type NFTAssetsResp []NFTAsset
+
+type NFTTxns struct {
+	ContractAddress string `json:"contract_address"`
+	TokenId         string `json:"token_id"`
+	TransactionHash string `json:"transaction_hash"`
+	BlockNumber     int    `json:"block_number"`
+	BlockHash       string `json:"block_hash"`
+	TransactionIdx  int    `json:"transaction_idx"`
+	LogIdx          int    `json:"log_idx"`
+	Sender          string `json:"sender"`
+	To              string `json:"to"`
+}
+
+type NFTTxnsResp []NFTTxns
+
+type NFTByTokenIDResp struct {
+	ContractAddress string `json:"contract_address"`
+	TokenId         string `json:"token_id"`
+	TokenUri        string `json:"token_uri"`
+	ActualOwner     string `json:"actual_owner"`
+	Properties      []struct {
+		TraitType   string      `json:"trait_type"`
+		Value       interface{} `json:"value"`
+		DisplayType string      `json:"display_type"`
+	} `json:"properties,omitempty"`
+	ImageUrl       string `json:"image_url,omitempty"`
+	Name           string `json:"name"`
+	Type           string `json:"type"`
+	Price          string `json:"price"`
+	AnimationUrl   string `json:"animation_url"`
+	EntireResponse string `json:"entire_response"`
+	Description    string `json:"description"`
+}
+
+//NFTHolderResponse the response is an array of addresses
+type NFTHolderResponse []string

--- a/pkg/token_price/token_price_impl_test.go
+++ b/pkg/token_price/token_price_impl_test.go
@@ -26,6 +26,10 @@ func TestPriceStoreV1_GetPrice(t1 *testing.T) {
 
 		resp, _ = ps.GetPriceAtInstant(chain, "invalidAddr", time)
 		ast.Empty(resp, "should have an empty response for an invalid call")
+
+		//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
+		_, err = ps.GetPriceAtInstant(constants.HUOBI, "", 0)
+		ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
 	})
 
 	t1.Run("Evaluate Get  Current Price", func(t *testing.T) {
@@ -36,6 +40,10 @@ func TestPriceStoreV1_GetPrice(t1 *testing.T) {
 
 		resp, _ = ps.GetCurrentPrice(chain, "invalidAddr")
 		ast.Empty(resp, "should have an empty response for an invalid call")
+
+		//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
+		_, err = ps.GetCurrentPrice(constants.HUOBI, "")
+		ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
 	})
 
 }
@@ -65,6 +73,10 @@ func TestPriceStoreV1_GetLPTokens(t *testing.T) {
 
 		resp, _ = ps.GetLPTokens(chain, "")
 		ast.Empty(resp, "should have an empty response for an invalid call")
+
+		//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
+		_, err = ps.GetLPTokens(constants.HUOBI, "")
+		ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
 	})
 }
 
@@ -107,6 +119,10 @@ func TestPriceStoreV1_GetLosers(t *testing.T) {
 
 	ast.NoError(err, "There should be no error for a valid call")
 	ast.NotEmpty(resp, "The response should not be empty")
+
+	//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
+	_, err = ps.GetLosers(constants.HUOBI)
+	ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
 }
 
 func TestPriceStoreV1_GetGainers(t *testing.T) {
@@ -117,4 +133,8 @@ func TestPriceStoreV1_GetGainers(t *testing.T) {
 
 	ast.NoError(err, "There should be no error for a valid call")
 	ast.NotEmpty(resp, "The response should not be empty")
+
+	//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
+	_, err = ps.GetGainers(constants.HUOBI)
+	ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
 }

--- a/pkg/unmarshal.go
+++ b/pkg/unmarshal.go
@@ -4,6 +4,7 @@ import (
 	"github.com/eucrypt/unmarshal-go-sdk/pkg/assets"
 	conf "github.com/eucrypt/unmarshal-go-sdk/pkg/config"
 	httpclient "github.com/eucrypt/unmarshal-go-sdk/pkg/http"
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/nft_details"
 	"github.com/eucrypt/unmarshal-go-sdk/pkg/session"
 	"github.com/eucrypt/unmarshal-go-sdk/pkg/token_details"
 	"github.com/eucrypt/unmarshal-go-sdk/pkg/token_price"
@@ -13,6 +14,7 @@ type Unmarshal struct {
 	token_details.TokenDetails
 	token_price.PriceStore
 	assets.Assets
+	nft_details.NftDetails
 }
 
 func NewWithConfig(config conf.Config) Unmarshal {
@@ -27,6 +29,7 @@ func NewWithConfig(config conf.Config) Unmarshal {
 		TokenDetails: token_details.New(sess),
 		PriceStore:   token_price.New(sess),
 		Assets:       assets.New(sess),
+		NftDetails:   nft_details.New(sess),
 	}
 }
 
@@ -36,6 +39,7 @@ func NewWithOptions(authKey string, options ...conf.ConfigOptions) Unmarshal {
 	return Unmarshal{
 		TokenDetails: token_details.New(sess),
 		PriceStore:   token_price.New(sess),
-		Assets:     assets.New(sess),
+		Assets:       assets.New(sess),
+		NftDetails:   nft_details.New(sess),
 	}
 }


### PR DESCRIPTION
This PR adds support for the [NFT APIs](https://docs.unmarshal.io/nft-apis)

The PR adds support for the following:
- `v1/:chain/address/:address/nft-assets`  (`GetAssetsByAddress`)
- `v1/:chain/address/:address/nft-transactions` (`GetTransactionsByAddress`)
- `v1/:chain/address/:address/details?tokenId=` (`GetDetailsByID`)
- `v1/:chain/address/:address/nftholders?tokenId=` (`GetHolderByID`)