### PR TITLE
Adding Protocol APIs to the SDK

### DIFF
--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -6,5 +6,5 @@ import (
 )
 
 type Assets interface {
-	GetAssets(chain constants.Chain, address string) (response types.AssetDetailsV1Resp, err error)
+	GetTokenAssets(chain constants.Chain, address string) (response types.AssetDetailsV1Resp, err error)
 }

--- a/pkg/assets/assets_store_impl.go
+++ b/pkg/assets/assets_store_impl.go
@@ -15,13 +15,13 @@ func New(sess session.Session) V1Store {
 	return V1Store{sess: sess}
 }
 
-//GetAssets accepts the chain and address and returns the assets of the address on the chain. It includes,
+//GetTokenAssets accepts the chain and address and returns the assets of the address on the chain. It includes,
 //in addition to the native token balances, all ERC20 assets (EVM chains) or SPL tokens (Solana)
-func (a V1Store) GetAssets(chain constants.Chain, address string) (response types.AssetDetailsV1Resp, err error) {
-	if !constants.ASSETS_GetAssets.SupportsChain(chain) {
+func (a V1Store) GetTokenAssets(chain constants.Chain, address string) (response types.AssetDetailsV1Resp, err error) {
+	if !constants.ASSETS_GetTokenAssets.SupportsChain(chain) {
 		return response, constants.UnsupportedChainError
 	}
-	path := strings.Replace(constants.ASSETS_GetAssets.GetURI(), ":chain", chain.String(), 1)
+	path := strings.Replace(constants.ASSETS_GetTokenAssets.GetURI(), ":chain", chain.String(), 1)
 	path = strings.Replace(path, ":address", address, 1)
 	err = a.sess.Client.Get(&response, path, nil)
 	return

--- a/pkg/assets/assets_store_impl_test.go
+++ b/pkg/assets/assets_store_impl_test.go
@@ -16,12 +16,12 @@ func TestV1Store_GetAssets(t *testing.T) {
 	validAddr := "demo.eth"
 	chain := constants.ETH
 	t.Run("Evaluate Get  Current Price", func(t *testing.T) {
-		resp, err := ps.GetAssets(chain, validAddr)
+		resp, err := ps.GetTokenAssets(chain, validAddr)
 
 		ast.NoError(err, "There should be no error for a valid call")
 		ast.NotEmpty(resp, "The response should not be empty")
 
-		resp, _ = ps.GetAssets(chain, "invalidAddr")
+		resp, _ = ps.GetTokenAssets(chain, "invalidAddr")
 		ast.Empty(resp, "should have an empty response for an invalid call")
 	})
 }

--- a/pkg/constants/api_name.go
+++ b/pkg/constants/api_name.go
@@ -1,0 +1,56 @@
+package constants
+
+type APIName string
+
+const (
+	PS_GetPriceWithAddress    APIName = "v1/pricestore/chain/:chain/:address"
+	PS_GetTokensPrice         APIName = "v1/pricestore/chain/:chain/tokens"
+	PS_GetLpTokenPrice        APIName = "v1/pricestore/chain/:chain/lptokens"
+	PS_GetLosers              APIName = "v1/pricestore/chain/:chain/losers"
+	PS_GetGainers             APIName = "v1/pricestore/chain/:chain/gainers"
+	PS_GetPriceWithSymbol     APIName = "v1/pricestore/:symbol"
+	TS_GetDetailsWithContract APIName = "v1/tokenstore/token/address/:address"
+	TS_GetTokenList           APIName = "v1/tokenstore/token/all"
+	TS_GetTokenWithSymbol     APIName = "v1/tokenstore/token/symbol/:symbol"
+	ASSETS_GetAssets          APIName = "v1/:chain/address/:address/assets"
+	NFT_GetAssets             APIName = "v1/:chain/address/:address/nft-assets"
+	NFT_GetTxns               APIName = "v1/:chain/address/:address/nft-transactions"
+	NFT_GetDetailsWithID      APIName = "v1/:chain/address/:address/details"
+	NFT_GetHoldersByID        APIName = "v1/:chain/address/:address/nftholders"
+	TXN_GetTokenTxns          APIName = "v1/:chain/address/:address/transactions"
+	TXN_GetTxnDetails         APIName = "v1/:chain/transactions/:txnID"
+	TXN_GetTokenTxnsV2        APIName = "v2/:chain/address/:address/transactions"
+	PROTO_GetPositions        APIName = "v2/protocols/:protocol/address/:address/positions"
+	PROTO_GetPairs            APIName = "v2/protocols/:protocol/pairs"
+)
+
+//SupportsChain Allows a caller to know if a chain specific API supports a passed valid chain
+func (api APIName) SupportsChain(chain Chain) bool {
+	if allowedCallersByChain[api] == nil {
+		return false
+	}
+
+	return allowedCallersByChain[api][chain]
+}
+
+//SupportsProtocol Allows a caller to know if a protocol specific API supports a passed valid chain
+func (api APIName) SupportsProtocol(protocol Protocol) bool {
+	if allowedCallersByProtocol[api] == nil {
+		return false
+	}
+	return allowedCallersByProtocol[api][protocol]
+}
+
+func (api APIName) GetURI() string {
+	return string(api)
+}
+
+//GetSupportedChains fetches all chains that an API supports as a map of Chain -> bool
+func (api APIName) GetSupportedChains() map[Chain]bool {
+	return allowedCallersByChain[api]
+}
+
+//GetSupportedProtocols fetches all Protocols that an API supports as a map of Protocol -> bool
+func (api APIName) GetSupportedProtocols() map[Protocol]bool {
+	return allowedCallersByProtocol[api]
+}

--- a/pkg/constants/api_name.go
+++ b/pkg/constants/api_name.go
@@ -12,8 +12,8 @@ const (
 	TS_GetDetailsWithContract APIName = "v1/tokenstore/token/address/:address"
 	TS_GetTokenList           APIName = "v1/tokenstore/token/all"
 	TS_GetTokenWithSymbol     APIName = "v1/tokenstore/token/symbol/:symbol"
-	ASSETS_GetAssets          APIName = "v1/:chain/address/:address/assets"
-	NFT_GetAssets             APIName = "v1/:chain/address/:address/nft-assets"
+	ASSETS_GetTokenAssets     APIName = "v1/:chain/address/:address/assets"
+	NFT_GetNFTAssets          APIName = "v1/:chain/address/:address/nft-assets"
 	NFT_GetTxns               APIName = "v1/:chain/address/:address/nft-transactions"
 	NFT_GetDetailsWithID      APIName = "v1/:chain/address/:address/details"
 	NFT_GetHoldersByID        APIName = "v1/:chain/address/:address/nftholders"
@@ -23,6 +23,22 @@ const (
 	PROTO_GetPositions        APIName = "v2/protocols/:protocol/address/:address/positions"
 	PROTO_GetPairs            APIName = "v2/protocols/:protocol/pairs"
 )
+
+var allowedCallersByChain = map[APIName]map[Chain]bool{
+	PS_GetPriceWithAddress: priceStoreSupported,
+	PS_GetTokensPrice:      priceStoreSupported,
+	PS_GetLpTokenPrice:     priceStoreSupported,
+	PS_GetLosers:           priceStoreSupported,
+	PS_GetGainers:          priceStoreSupported,
+	ASSETS_GetTokenAssets:  allChains,
+	NFT_GetNFTAssets:       {ETH: true, BSC: true, MATIC: true, SOL: true},
+	NFT_GetTxns:            nftEVMSupport,
+	NFT_GetDetailsWithID:   nftEVMSupport,
+	NFT_GetHoldersByID:     nftEVMSupport,
+	TXN_GetTokenTxns:       {ETH: true, BSC: true, MATIC: true, SOL: true, ZILLIQA: true, XDC: true},
+	TXN_GetTxnDetails:      {ETH: true, BSC: true, MATIC: true, SOL: true, XDC: true},
+	TXN_GetTokenTxnsV2:     {ETH: true, BSC: true, XDC: true},
+}
 
 //SupportsChain Allows a caller to know if a chain specific API supports a passed valid chain
 func (api APIName) SupportsChain(chain Chain) bool {

--- a/pkg/constants/chain.go
+++ b/pkg/constants/chain.go
@@ -21,22 +21,6 @@ var priceStoreSupported = map[Chain]bool{ETH: true, BSC: true, MATIC: true}
 
 var nftEVMSupport = map[Chain]bool{ETH: true, BSC: true, MATIC: true}
 
-var allowedCallersByChain = map[APIName]map[Chain]bool{
-	PS_GetPriceWithAddress: priceStoreSupported,
-	PS_GetTokensPrice:      priceStoreSupported,
-	PS_GetLpTokenPrice:     priceStoreSupported,
-	PS_GetLosers:           priceStoreSupported,
-	PS_GetGainers:          priceStoreSupported,
-	ASSETS_GetAssets:       allChains,
-	NFT_GetAssets:          {ETH: true, BSC: true, MATIC: true, SOL: true},
-	NFT_GetTxns:            nftEVMSupport,
-	NFT_GetDetailsWithID:   nftEVMSupport,
-	NFT_GetHoldersByID:     nftEVMSupport,
-	TXN_GetTokenTxns:       {ETH: true, BSC: true, MATIC: true, SOL: true, ZILLIQA: true, XDC: true},
-	TXN_GetTxnDetails:      {ETH: true, BSC: true, MATIC: true, SOL: true, XDC: true},
-	TXN_GetTokenTxnsV2:     {ETH: true, BSC: true, XDC: true},
-}
-
 //String returns the string specific version of the chain
 func (c Chain) String() string {
 	return string(c)

--- a/pkg/constants/chain.go
+++ b/pkg/constants/chain.go
@@ -3,7 +3,6 @@ package constants
 import "errors"
 
 type Chain string
-type APIName string
 
 const (
 	ETH     Chain = "ethereum"
@@ -15,26 +14,6 @@ const (
 	HUOBI   Chain = "heco"
 )
 
-const (
-	PS_GetPriceWithAddress    APIName = "v1/pricestore/chain/:chain/:address"
-	PS_GetTokensPrice         APIName = "v1/pricestore/chain/:chain/tokens"
-	PS_GetLpTokenPrice        APIName = "v1/pricestore/chain/:chain/lptokens"
-	PS_GetLosers              APIName = "v1/pricestore/chain/:chain/losers"
-	PS_GetGainers             APIName = "v1/pricestore/chain/:chain/gainers"
-	PS_GetPriceWithSymbol     APIName = "v1/pricestore/:symbol"
-	TS_GetDetailsWithContract APIName = "v1/tokenstore/token/address/:address"
-	TS_GetTokenList           APIName = "v1/tokenstore/token/all"
-	TS_GetTokenWithSymbol     APIName = "v1/tokenstore/token/symbol/:symbol"
-	ASSETS_GetAssets          APIName = "v1/:chain/address/:address/assets"
-	NFT_GetAssets             APIName = "v1/:chain/address/:address/nft-assets"
-	NFT_GetTxns               APIName = "v1/:chain/address/:address/nft-transactions"
-	NFT_GetDetailsWithID      APIName = "v1/:chain/address/:address/details"
-	NFT_GetHoldersByID        APIName = "v1/:chain/address/:address/nftholders"
-	TXN_GetTokenTxns          APIName = "v1/:chain/address/:address/transactions"
-	TXN_GetTxnDetails         APIName = "v1/:chain/transactions/:txnID"
-	TXN_GetTokenTxnsV2        APIName = "v2/:chain/address/:address/transactions"
-)
-
 //This should be manually changed when a new chain starts being supported
 var allChains = map[Chain]bool{ETH: true, BSC: true, MATIC: true, XDC: true, SOL: true, ZILLIQA: true, HUOBI: true}
 
@@ -42,7 +21,7 @@ var priceStoreSupported = map[Chain]bool{ETH: true, BSC: true, MATIC: true}
 
 var nftEVMSupport = map[Chain]bool{ETH: true, BSC: true, MATIC: true}
 
-var allowedCallersByAPI = map[APIName]map[Chain]bool{
+var allowedCallersByChain = map[APIName]map[Chain]bool{
 	PS_GetPriceWithAddress: priceStoreSupported,
 	PS_GetTokensPrice:      priceStoreSupported,
 	PS_GetLpTokenPrice:     priceStoreSupported,
@@ -61,24 +40,6 @@ var allowedCallersByAPI = map[APIName]map[Chain]bool{
 //String returns the string specific version of the chain
 func (c Chain) String() string {
 	return string(c)
-}
-
-//SupportsChain Allows a caller to know if a chain specific API supports a passed valid chain
-func (api APIName) SupportsChain(chain Chain) bool {
-	if allowedCallersByAPI[api] == nil {
-		return false
-	}
-
-	return allowedCallersByAPI[api][chain]
-}
-
-func (api APIName) GetURI() string {
-	return string(api)
-}
-
-//GetSupportedChains fetches all chains that an API supports as a map of Chain -> bool
-func (api APIName) GetSupportedChains() map[Chain]bool {
-	return allowedCallersByAPI[api]
 }
 
 var UnsupportedChainError = errors.New("unsupported chain for API")

--- a/pkg/constants/protocol.go
+++ b/pkg/constants/protocol.go
@@ -7,14 +7,12 @@ type Protocol string
 const (
 	PancakeswapV1 Protocol = "pancakeswap_v1"
 	PancakeswapV2 Protocol = "pancakeswap_v2"
-	Uniswap       Protocol = "uniswap"
 	UniswapV2     Protocol = "uniswap_v2"
 )
 
 var allProtocols = map[Protocol]bool{
 	PancakeswapV1: true,
 	PancakeswapV2: true,
-	Uniswap:       true,
 	UniswapV2:     true,
 }
 var allowedCallersByProtocol = map[APIName]map[Protocol]bool{

--- a/pkg/constants/protocol.go
+++ b/pkg/constants/protocol.go
@@ -1,0 +1,30 @@
+package constants
+
+import "errors"
+
+type Protocol string
+
+const (
+	PancakeswapV1 Protocol = "pancakeswap_v1"
+	PancakeswapV2 Protocol = "pancakeswap_v2"
+	Uniswap       Protocol = "uniswap"
+	UniswapV2     Protocol = "uniswap_v2"
+)
+
+var allProtocols = map[Protocol]bool{
+	PancakeswapV1: true,
+	PancakeswapV2: true,
+	Uniswap:       true,
+	UniswapV2:     true,
+}
+var allowedCallersByProtocol = map[APIName]map[Protocol]bool{
+	PROTO_GetPairs:     allProtocols,
+	PROTO_GetPositions: allProtocols,
+}
+
+//String returns the string specific version of the protocol
+func (c Protocol) String() string {
+	return string(c)
+}
+
+var UnsupportedProtocolError = errors.New("unsupported protocol for API")

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -1,6 +1,5 @@
 package httpclient
 
-import "C"
 import (
 	"bytes"
 	"context"

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -71,15 +71,15 @@ func (r *Request) GetWithContext(result interface{}, path string, query url.Valu
 	return r.Execute("GET", uri, nil, result, ctx)
 }
 
-//GET makes an HTTP GET call after appending the default query values in additon to the existing ones.
+// Get makes an HTTP GET call after appending the default query values in addition to the existing ones.
 func (r *Request) Get(result interface{}, path string, query url.Values) error {
 	queryStr := r.safeGetQueryStrWithDefaults(query)
 	uri := strings.Join([]string{r.GetBase(path), queryStr}, "?")
 	return r.Execute("GET", uri, nil, result, context.Background())
 }
 
-//safeGetQueryStrWithDefaults appends the default queries (auth key and other specified data) with creating a panic.
-//It returns the URL encoded query string ( "auth_key=value&item=value ..." )
+//safeGetQueryStrWithDefaults appends the default queries (auth key and other specified data) without creating a panic.
+//It returns the URL encoded query string ( "<url>?auth_key=value&item=value ..." )
 func (r *Request) safeGetQueryStrWithDefaults(query url.Values) string {
 	if query == nil {
 		query = make(url.Values)

--- a/pkg/nft_details/nft_details.go
+++ b/pkg/nft_details/nft_details.go
@@ -6,8 +6,8 @@ import (
 )
 
 type NftDetails interface {
-	GetAssetsByAddress(chain constants.Chain, address string) (response types.NFTAssetsResp, err error)
-	GetTransactionsByAddress(chain constants.Chain, address string, pageNumber int, pageSize int) (response types.NFTTxnsResp, err error)
-	GetDetailsByID(chain constants.Chain, tokenID string, NFTAddress string) (response types.NFTByTokenIDResp, err error)
-	GetHolderByID(chain constants.Chain, tokenID string, NFTAddress string) (response types.NFTHolderResponse, err error)
+	GetNFTAssetsByAddress(chain constants.Chain, address string) (response types.NFTAssetsResp, err error)
+	GetNFTTransactionsByAddress(chain constants.Chain, address string, pageNumber int, pageSize int) (response types.NFTTxnsResp, err error)
+	GetNFTDetailsByID(chain constants.Chain, tokenID string, NFTAddress string) (response types.NFTByTokenIDResp, err error)
+	GetNFTHolderByID(chain constants.Chain, tokenID string, NFTAddress string) (response types.NFTHolderResponse, err error)
 }

--- a/pkg/nft_details/nft_details_impl.go
+++ b/pkg/nft_details/nft_details_impl.go
@@ -17,18 +17,22 @@ func New(sess session.Session) NFTDetailsImpl {
 	return NFTDetailsImpl{sess: sess}
 }
 
-func (nft NFTDetailsImpl) GetAssetsByAddress(chain constants.Chain, address string) (resp types.NFTAssetsResp, err error) {
-	if !constants.NFT_GetAssets.SupportsChain(chain) {
+//GetNFTAssetsByAddress accepts a chain and address and returns the NFT assets in possession with the address.
+//For Solana it works only with the Metaplex NFTs wherein it returns assets whose metadata has a URI
+func (nft NFTDetailsImpl) GetNFTAssetsByAddress(chain constants.Chain, address string) (resp types.NFTAssetsResp, err error) {
+	if !constants.NFT_GetNFTAssets.SupportsChain(chain) {
 		return types.NFTAssetsResp{}, constants.UnsupportedChainError
 	}
-	path := strings.Replace(constants.NFT_GetAssets.GetURI(), ":chain", chain.String(), 1)
+	path := strings.Replace(constants.NFT_GetNFTAssets.GetURI(), ":chain", chain.String(), 1)
 	path = strings.Replace(path, ":address", address, 1)
 	err = nft.sess.Client.Get(&resp, path, nil)
 
 	return
 }
 
-func (nft NFTDetailsImpl) GetTransactionsByAddress(chain constants.Chain, address string, pageNumber int, pageSize int) (
+//GetNFTTransactionsByAddress accepts a chain, address and pagination params.
+//It returns the list of the address' NFT transactions
+func (nft NFTDetailsImpl) GetNFTTransactionsByAddress(chain constants.Chain, address string, pageNumber int, pageSize int) (
 	resp types.NFTTxnsResp, err error) {
 	if !constants.NFT_GetTxns.SupportsChain(chain) {
 		return types.NFTTxnsResp{}, constants.UnsupportedChainError
@@ -45,7 +49,8 @@ func (nft NFTDetailsImpl) GetTransactionsByAddress(chain constants.Chain, addres
 	return
 }
 
-func (nft NFTDetailsImpl) GetDetailsByID(chain constants.Chain, tokenID string, NFTAddress string) (
+//GetNFTDetailsByID accepts the NFT's tokenID, chain and address and returns the associated NFT metadata
+func (nft NFTDetailsImpl) GetNFTDetailsByID(chain constants.Chain, tokenID string, NFTAddress string) (
 	resp types.NFTByTokenIDResp, err error) {
 
 	if !constants.NFT_GetDetailsWithID.SupportsChain(chain) {
@@ -61,7 +66,7 @@ func (nft NFTDetailsImpl) GetDetailsByID(chain constants.Chain, tokenID string, 
 	return
 }
 
-func (nft NFTDetailsImpl) GetHolderByID(chain constants.Chain, tokenID string, NFTAddress string) (
+func (nft NFTDetailsImpl) GetNFTHolderByID(chain constants.Chain, tokenID string, NFTAddress string) (
 	resp types.NFTHolderResponse, err error) {
 
 	if !constants.NFT_GetHoldersByID.SupportsChain(chain) {

--- a/pkg/nft_details/nft_details_impl_test.go
+++ b/pkg/nft_details/nft_details_impl_test.go
@@ -17,16 +17,16 @@ func TestNFTDetailsImpl_GetAssetsByAddress(t *testing.T) {
 		validAddr := "demo.eth"
 		chain := constants.ETH
 
-		resp, err := nftObj.GetAssetsByAddress(chain, validAddr)
+		resp, err := nftObj.GetNFTAssetsByAddress(chain, validAddr)
 
 		ast.NoError(err, "There should be no error for a valid call")
 		ast.NotEmpty(resp, "The response should not be empty")
 
-		resp, _ = nftObj.GetAssetsByAddress(chain, "")
+		resp, _ = nftObj.GetNFTAssetsByAddress(chain, "")
 		ast.Empty(resp, "should have an empty response for an invalid call")
 
 		//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
-		_, err = nftObj.GetAssetsByAddress(constants.HUOBI, "")
+		_, err = nftObj.GetNFTAssetsByAddress(constants.HUOBI, "")
 		ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
 
 	})
@@ -53,16 +53,16 @@ func TestNFTDetailsImpl_GetDetailsByID(t *testing.T) {
 		validTokenId := "61"
 		validNFTAddr := "0x3cf8695c5cb6caa78d9c7fc9fa34bc8271483a1a"
 
-		resp, err := nftObj.GetDetailsByID(validChain, validTokenId, validNFTAddr)
+		resp, err := nftObj.GetNFTDetailsByID(validChain, validTokenId, validNFTAddr)
 
 		ast.NoError(err, "There should be no error for a valid call")
 		ast.NotEmpty(resp, "The response should not be empty")
 
-		resp, _ = nftObj.GetDetailsByID(validChain, "", "")
+		resp, _ = nftObj.GetNFTDetailsByID(validChain, "", "")
 		ast.Empty(resp, "should have an empty response for an invalid call")
 
 		//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
-		_, err = nftObj.GetDetailsByID(constants.HUOBI, "", "")
+		_, err = nftObj.GetNFTDetailsByID(constants.HUOBI, "", "")
 		ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
 	})
 	t.Run("Evaluating Get NFT Details by ID 2", func(t *testing.T) {
@@ -70,7 +70,7 @@ func TestNFTDetailsImpl_GetDetailsByID(t *testing.T) {
 		validTokenId := "1300020038"
 		validNFTAddr := "0x4629122c04eacc2ca48bda4a92aadcaee5d15389"
 
-		resp, err := nftObj.GetDetailsByID(validChain, validTokenId, validNFTAddr)
+		resp, err := nftObj.GetNFTDetailsByID(validChain, validTokenId, validNFTAddr)
 
 		ast.NoError(err, "There should be no error for a valid call")
 		ast.NotEmpty(resp, "The response should not be empty")
@@ -87,16 +87,16 @@ func TestNFTDetailsImpl_GetHolderByID(t *testing.T) {
 		validTokenId := "61"
 		validNFTAddr := "0x3cf8695c5cb6caa78d9c7fc9fa34bc8271483a1a"
 
-		resp, err := nftObj.GetHolderByID(validChain, validTokenId, validNFTAddr)
+		resp, err := nftObj.GetNFTHolderByID(validChain, validTokenId, validNFTAddr)
 
 		ast.NoError(err, "There should be no error for a valid call")
 		ast.NotEmpty(resp, "The response should not be empty")
 
-		resp, _ = nftObj.GetHolderByID(validChain, "", "")
+		resp, _ = nftObj.GetNFTHolderByID(validChain, "", "")
 		ast.Empty(resp, "should have an empty response for an invalid call")
 
 		//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
-		_, err = nftObj.GetHolderByID(constants.HUOBI, "", "")
+		_, err = nftObj.GetNFTHolderByID(constants.HUOBI, "", "")
 		ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
 	})
 	t.Run("Evaluating Get NFT Holders by Token ID 2", func(t *testing.T) {
@@ -104,7 +104,7 @@ func TestNFTDetailsImpl_GetHolderByID(t *testing.T) {
 		validTokenId := "1300020038"
 		validNFTAddr := "0x4629122c04eacc2ca48bda4a92aadcaee5d15389"
 
-		resp, err := nftObj.GetHolderByID(validChain, validTokenId, validNFTAddr)
+		resp, err := nftObj.GetNFTHolderByID(validChain, validTokenId, validNFTAddr)
 
 		ast.NoError(err, "There should be no error for a valid call")
 		ast.NotEmpty(resp, "The response should not be empty")
@@ -122,13 +122,13 @@ func TestNFTDetailsImpl_GetTransactionsByAddress(t *testing.T) {
 		pageNumber := 1
 		pageSize := 5
 
-		resp, err := nftObj.GetTransactionsByAddress(validChain, validAddr, pageNumber, pageSize)
+		resp, err := nftObj.GetNFTTransactionsByAddress(validChain, validAddr, pageNumber, pageSize)
 		ast.NoError(err, "There should be no error for a valid call")
 		ast.NotEmpty(resp, "The response should not be empty")
 		ast.Len(resp, 5, "Exactly 5 objects should be a part of the response")
 
 		//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
-		_, err = nftObj.GetTransactionsByAddress(constants.HUOBI, "", 0, 0)
+		_, err = nftObj.GetNFTTransactionsByAddress(constants.HUOBI, "", 0, 0)
 		ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
 	})
 	t.Run("Evaluating Get NFT Transactions By Address 2", func(t *testing.T) {
@@ -137,7 +137,7 @@ func TestNFTDetailsImpl_GetTransactionsByAddress(t *testing.T) {
 		pageNumber := 1
 		pageSize := 10
 
-		resp, err := nftObj.GetTransactionsByAddress(validChain, validAddr, pageNumber, pageSize)
+		resp, err := nftObj.GetNFTTransactionsByAddress(validChain, validAddr, pageNumber, pageSize)
 		ast.NoError(err, "There should be no error for a valid call")
 		ast.NotEmpty(resp, "The response should not be empty")
 		ast.Len(resp, 10, "Exactly 10 objects should be a part of the response")

--- a/pkg/protocol_details/protocol_details.go
+++ b/pkg/protocol_details/protocol_details.go
@@ -1,0 +1,11 @@
+package protocol_details
+
+import (
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/constants"
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/protocol_details/types"
+)
+
+type ProtocolDetails interface {
+	GetPairs(protocol constants.Protocol) (resp types.GetPairsResp, err error)
+	GetPositions(details constants.Protocol, address string) (resp types.GetPositionsResp, err error)
+}

--- a/pkg/protocol_details/protocol_details_impl.go
+++ b/pkg/protocol_details/protocol_details_impl.go
@@ -15,6 +15,8 @@ func New(sess session.Session) ProtocolDetailsImpl {
 	return ProtocolDetailsImpl{sess: sess}
 }
 
+//GetPairs fetches all the available tracks pairs of a given protocol.
+//It accepts constants.Protocol as the input and returns the valid and tracked pairs
 func (protoImpl ProtocolDetailsImpl) GetPairs(protocol constants.Protocol) (resp types.GetPairsResp, err error) {
 	if !constants.PROTO_GetPairs.SupportsProtocol(protocol) {
 		return types.GetPairsResp{}, constants.UnsupportedProtocolError
@@ -26,6 +28,8 @@ func (protoImpl ProtocolDetailsImpl) GetPairs(protocol constants.Protocol) (resp
 	return
 }
 
+//GetPositions fetches the positions an address holds wrt a particular protocol (constants.Protocol).
+//It accepts an address and the protocol.
 func (protoImpl ProtocolDetailsImpl) GetPositions(protocol constants.Protocol, address string) (
 	resp types.GetPositionsResp, err error) {
 	if !constants.PROTO_GetPositions.SupportsProtocol(protocol) {

--- a/pkg/protocol_details/protocol_details_impl.go
+++ b/pkg/protocol_details/protocol_details_impl.go
@@ -1,0 +1,40 @@
+package protocol_details
+
+import (
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/constants"
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/protocol_details/types"
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/session"
+	"strings"
+)
+
+type ProtocolDetailsImpl struct {
+	sess session.Session
+}
+
+func New(sess session.Session) ProtocolDetailsImpl {
+	return ProtocolDetailsImpl{sess: sess}
+}
+
+func (protoImpl ProtocolDetailsImpl) GetPairs(protocol constants.Protocol) (resp types.GetPairsResp, err error) {
+	if !constants.PROTO_GetPairs.SupportsProtocol(protocol) {
+		return types.GetPairsResp{}, constants.UnsupportedProtocolError
+	}
+
+	path := strings.Replace(constants.PROTO_GetPairs.GetURI(), ":protocol", protocol.String(), 1)
+	err = protoImpl.sess.Client.Get(&resp, path, nil)
+
+	return
+}
+
+func (protoImpl ProtocolDetailsImpl) GetPositions(protocol constants.Protocol, address string) (
+	resp types.GetPositionsResp, err error) {
+	if !constants.PROTO_GetPositions.SupportsProtocol(protocol) {
+		return types.GetPositionsResp{}, constants.UnsupportedProtocolError
+	}
+
+	path := strings.Replace(constants.PROTO_GetPositions.GetURI(), ":protocol", protocol.String(), 1)
+	path = strings.Replace(path, ":address", address, 1)
+	err = protoImpl.sess.Client.Get(&resp, path, nil)
+
+	return
+}

--- a/pkg/protocol_details/protocol_details_impl_test.go
+++ b/pkg/protocol_details/protocol_details_impl_test.go
@@ -20,7 +20,7 @@ func TestProtocolDetailsImpl_GetPairs(t *testing.T) {
 		resp, err := protoObj.GetPairs(validProtocol)
 
 		ast.NoError(err, "There should be no error for a valid call")
-		ast.NotEmpty(resp, "The response should not be empty")
+		ast.NotEmpty(resp.ProtocolPairs, "The response should not be empty")
 	})
 }
 
@@ -29,13 +29,13 @@ func TestProtocolDetailsImpl_GetPositions(t *testing.T) {
 	ast := assert.New(t)
 
 	t.Run("Evaluating Get Pairs with valid data", func(t *testing.T) {
-		validProtocol := constants.PancakeswapV2
+		validProtocol := constants.UniswapV2
 		validAddress := "demo.eth"
 
 		resp, err := protoObj.GetPositions(validProtocol, validAddress)
 
 		ast.NoError(err, "There should be no error for a valid call")
-		ast.NotEmpty(resp, "The response should not be empty")
+		ast.NotEmpty(resp.Positions, "The response should have valid positions")
 	})
 	t.Run("Evaluating Get Pairs with invalid data", func(t *testing.T) {
 		validProtocol := constants.PancakeswapV2
@@ -43,7 +43,8 @@ func TestProtocolDetailsImpl_GetPositions(t *testing.T) {
 
 		resp, _ := protoObj.GetPositions(validProtocol, validAddress)
 
-		ast.Empty(resp, "The response should be empty for invalid data")
+		//@dev at the time of writing, the address held 0 positions. This could change leading to a failed test
+		ast.Len(resp.Positions, 0, "The number of valid positions must be 0")
 	})
 
 }

--- a/pkg/protocol_details/protocol_details_impl_test.go
+++ b/pkg/protocol_details/protocol_details_impl_test.go
@@ -1,0 +1,60 @@
+package protocol_details
+
+import (
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/constants"
+	httpclient "github.com/eucrypt/unmarshal-go-sdk/pkg/http"
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/session"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestProtocolDetailsImpl_GetPairs(t *testing.T) {
+	protoObj := getTestProtocolDetailsImpl()
+	ast := assert.New(t)
+
+	t.Run("Evaluating Get Pairs with valid data", func(t *testing.T) {
+		validProtocol := constants.PancakeswapV2
+
+		resp, err := protoObj.GetPairs(validProtocol)
+
+		ast.NoError(err, "There should be no error for a valid call")
+		ast.NotEmpty(resp, "The response should not be empty")
+	})
+}
+
+func TestProtocolDetailsImpl_GetPositions(t *testing.T) {
+	protoObj := getTestProtocolDetailsImpl()
+	ast := assert.New(t)
+
+	t.Run("Evaluating Get Pairs with valid data", func(t *testing.T) {
+		validProtocol := constants.PancakeswapV2
+		validAddress := "demo.eth"
+
+		resp, err := protoObj.GetPositions(validProtocol, validAddress)
+
+		ast.NoError(err, "There should be no error for a valid call")
+		ast.NotEmpty(resp, "The response should not be empty")
+	})
+	t.Run("Evaluating Get Pairs with invalid data", func(t *testing.T) {
+		validProtocol := constants.PancakeswapV2
+		validAddress := "demo.eth"
+
+		resp, _ := protoObj.GetPositions(validProtocol, validAddress)
+
+		ast.Empty(resp, "The response should be empty for invalid data")
+	})
+
+}
+func getTestProtocolDetailsImpl() ProtocolDetailsImpl {
+	httpClient := httpclient.NewHttpJSONClient(constants.Environment.GetEndpoint("prod"))
+	authKey := os.Getenv("API_KEY")
+	httpClient.DefaultQuery = map[string]string{"auth_key": authKey}
+	details := New(session.Session{Config: struct {
+		AuthKey     string
+		HttpClient  *http.Client
+		Environment constants.Environment
+	}{AuthKey: authKey, HttpClient: nil, Environment: constants.Prod}, Client: httpClient})
+	return details
+}

--- a/pkg/protocol_details/types/types.go
+++ b/pkg/protocol_details/types/types.go
@@ -1,7 +1,5 @@
 package types
 
-//TODO:Set up response structs
-
 type GetPairsResp struct {
 	Total         int `json:"total"`
 	ProtocolPairs []struct {

--- a/pkg/protocol_details/types/types.go
+++ b/pkg/protocol_details/types/types.go
@@ -3,7 +3,97 @@ package types
 //TODO:Set up response structs
 
 type GetPairsResp struct {
+	Total         int `json:"total"`
+	ProtocolPairs []struct {
+		Token0 struct {
+			ContractName         string  `json:"contract_name"`
+			ContractTickerSymbol string  `json:"contract_ticker_symbol"`
+			ContractDecimals     int     `json:"contract_decimals"`
+			ContractAddress      string  `json:"contract_address"`
+			Coin                 int     `json:"coin"`
+			Quote                int     `json:"quote"`
+			QuoteRate            float64 `json:"quote_rate"`
+			LogoUrl              string  `json:"logo_url"`
+			QuoteRate24H         string  `json:"quote_rate_24h"`
+			QuotePctChange24H    int     `json:"quote_pct_change_24h"`
+		} `json:"token_0"`
+		Token1 struct {
+			ContractName         string  `json:"contract_name"`
+			ContractTickerSymbol string  `json:"contract_ticker_symbol"`
+			ContractDecimals     int     `json:"contract_decimals"`
+			ContractAddress      string  `json:"contract_address"`
+			Coin                 int     `json:"coin"`
+			Quote                int     `json:"quote"`
+			QuoteRate            float64 `json:"quote_rate"`
+			LogoUrl              string  `json:"logo_url"`
+			QuoteRate24H         string  `json:"quote_rate_24h"`
+			QuotePctChange24H    int     `json:"quote_pct_change_24h"`
+		} `json:"token_1"`
+		Pair struct {
+			ContractName         string  `json:"contract_name"`
+			ContractTickerSymbol string  `json:"contract_ticker_symbol"`
+			ContractDecimals     int     `json:"contract_decimals"`
+			ContractAddress      string  `json:"contract_address"`
+			Coin                 int     `json:"coin"`
+			Quote                int     `json:"quote"`
+			QuoteRate            float64 `json:"quote_rate"`
+			LogoUrl              string  `json:"logo_url"`
+			QuoteRate24H         string  `json:"quote_rate_24h"`
+			QuotePctChange24H    int     `json:"quote_pct_change_24h"`
+		} `json:"pair"`
+		TotalLiquidityQuote  string `json:"total_liquidity_quote"`
+		Token0Reserve        string `json:"token_0_reserve"`
+		Token1Reserve        string `json:"token_1_reserve"`
+		CreatedAtBlockNumber string `json:"created_at_block_number"`
+	} `json:"protocol_pairs"`
 }
 
 type GetPositionsResp struct {
+	UserAddress string `json:"user_address"`
+	Positions   []struct {
+		Token0Reserve string `json:"token_0_reserve"`
+		Token1Reserve string `json:"token_1_reserve"`
+		Token0        struct {
+			ContractName         string `json:"contract_name"`
+			ContractTickerSymbol string `json:"contract_ticker_symbol"`
+			ContractDecimals     int    `json:"contract_decimals"`
+			ContractAddress      string `json:"contract_address"`
+			Coin                 int    `json:"coin"`
+			Balance              string `json:"balance"`
+			Quote                int    `json:"quote"`
+			QuoteRate            int    `json:"quote_rate"`
+			LogoUrl              string `json:"logo_url"`
+			QuoteRate24H         string `json:"quote_rate_24h"`
+			QuotePctChange24H    int    `json:"quote_pct_change_24h"`
+		} `json:"token_0"`
+		Token1 struct {
+			ContractName         string `json:"contract_name"`
+			ContractTickerSymbol string `json:"contract_ticker_symbol"`
+			ContractDecimals     int    `json:"contract_decimals"`
+			ContractAddress      string `json:"contract_address"`
+			Coin                 int    `json:"coin"`
+			Balance              string `json:"balance"`
+			Quote                int    `json:"quote"`
+			QuoteRate            int    `json:"quote_rate"`
+			LogoUrl              string `json:"logo_url"`
+			QuoteRate24H         string `json:"quote_rate_24h"`
+			QuotePctChange24H    int    `json:"quote_pct_change_24h"`
+		} `json:"token_1"`
+		PoolToken struct {
+			ContractName         string  `json:"contract_name"`
+			ContractTickerSymbol string  `json:"contract_ticker_symbol"`
+			ContractDecimals     int     `json:"contract_decimals"`
+			ContractAddress      string  `json:"contract_address"`
+			Coin                 int     `json:"coin"`
+			Balance              string  `json:"balance"`
+			Quote                float64 `json:"quote"`
+			QuoteRate            float64 `json:"quote_rate"`
+			LogoUrl              string  `json:"logo_url"`
+			QuoteRate24H         string  `json:"quote_rate_24h"`
+			QuotePctChange24H    int     `json:"quote_pct_change_24h"`
+			TotalSupply          string  `json:"total_supply"`
+			PoolSharePercentage  string  `json:"pool_share_percentage"`
+			LiquidityValue       float64 `json:"liquidity_value"`
+		} `json:"pool_token"`
+	} `json:"positions"`
 }

--- a/pkg/protocol_details/types/types.go
+++ b/pkg/protocol_details/types/types.go
@@ -1,0 +1,9 @@
+package types
+
+//TODO:Set up response structs
+
+type GetPairsResp struct {
+}
+
+type GetPositionsResp struct {
+}

--- a/pkg/token_details/token_details.go
+++ b/pkg/token_details/token_details.go
@@ -3,7 +3,7 @@ package token_details
 import "github.com/eucrypt/unmarshal-go-sdk/pkg/token_details/types"
 
 type TokenDetails interface {
-	GetDetailsWithContract(contractAddress string) (types.TokenDetails, error)
+	GetTokenDetailsByContract(contractAddress string) (types.TokenDetails, error)
 	GetTokenList(pageNumber int, pageSize int) (types.GetTokenListResponse, error)
-	GetTokenWithSymbol(string) ([]types.TokenDetails, error)
+	GetTokenDetailsBySymbol(string) ([]types.TokenDetails, error)
 }

--- a/pkg/token_details/token_details_impl.go
+++ b/pkg/token_details/token_details_impl.go
@@ -17,9 +17,9 @@ func New(sess session.Session) TokenStoreV1 {
 	return TokenStoreV1{sess}
 }
 
-//GetDetailsWithContract returns token data when provided with a valid contract.
+//GetTokenDetailsByContract returns token data when provided with a valid contract.
 //The search happens across every supported chain
-func (t TokenStoreV1) GetDetailsWithContract(contractAddress string) (resp types.TokenDetails, err error) {
+func (t TokenStoreV1) GetTokenDetailsByContract(contractAddress string) (resp types.TokenDetails, err error) {
 	path := strings.Replace(constants.TS_GetDetailsWithContract.GetURI(), ":address", contractAddress, 1)
 	err = t.sess.Client.Get(&resp, path, nil)
 	return
@@ -38,9 +38,9 @@ func (t TokenStoreV1) GetTokenList(pageNumber int, pageSize int) (resp types.Get
 	return
 }
 
-//GetTokenWithSymbol Accepts a symbol and returns token data.
+//GetTokenDetailsBySymbol Accepts a symbol and returns token data.
 //The search is cross-chain and the result includes the blockchain of the specific token
-func (t TokenStoreV1) GetTokenWithSymbol(symbol string) (resp []types.TokenDetails, err error) {
+func (t TokenStoreV1) GetTokenDetailsBySymbol(symbol string) (resp []types.TokenDetails, err error) {
 	path := strings.Replace(constants.TS_GetTokenWithSymbol.GetURI(), ":symbol", symbol, 1)
 	err = t.sess.Client.Get(&resp, path, nil)
 	return

--- a/pkg/token_details/token_details_impl_test.go
+++ b/pkg/token_details/token_details_impl_test.go
@@ -17,13 +17,13 @@ func TestTokenStoreV1_GetTokenDetailsWithContract(t *testing.T) {
 	ValidContract := "0x5a666c7d92e5fa7edcb6390e4efd6d0cdd69cf37"
 	ast := assert.New(t)
 	t.Run("Evaluating get Token Details with valid data", func(t *testing.T) {
-		resp, err := ts.GetDetailsWithContract(ValidContract)
+		resp, err := ts.GetTokenDetailsByContract(ValidContract)
 		ast.NoError(err, "There should be no error for a valid call")
 		ast.NotEmpty(resp, "The response should not be empty")
 	})
 
 	t.Run("Evaluating get Token Details with invalid data", func(t *testing.T) {
-		resp, _ := ts.GetDetailsWithContract("")
+		resp, _ := ts.GetTokenDetailsByContract("")
 		ast.Empty(resp, "The response should be empty for invalid data")
 	})
 
@@ -65,14 +65,14 @@ func TestTokenStoreV1_GetTokenWithSymbol(t *testing.T) {
 	ts := getTestTokenStore()
 	validSymbol := "marsh"
 	ast := assert.New(t)
-	t.Run("Evaluating GetTokenWithSymbol with valid data", func(t *testing.T) {
-		resp, err := ts.GetTokenWithSymbol(validSymbol)
+	t.Run("Evaluating GetTokenDetailsBySymbol with valid data", func(t *testing.T) {
+		resp, err := ts.GetTokenDetailsBySymbol(validSymbol)
 		ast.NoError(err, "There should be no error for a valid call")
 		ast.NotEmpty(resp, "The response should not be empty")
 	})
 
-	t.Run("Evaluating GetTokenWithSymbol with invalid data", func(t *testing.T) {
-		resp, _ := ts.GetTokenWithSymbol("")
+	t.Run("Evaluating GetTokenDetailsBySymbol with invalid data", func(t *testing.T) {
+		resp, _ := ts.GetTokenDetailsBySymbol("")
 		ast.Empty(resp, "The response should be empty for invalid data")
 	})
 

--- a/pkg/token_price/token_price.go
+++ b/pkg/token_price/token_price.go
@@ -6,11 +6,11 @@ import (
 )
 
 type PriceStore interface {
-	GetPriceAtInstant(chain constants.Chain, contractAddress string, timestamp int64) (types.TokenPrice, error)
-	GetCurrentPrice(chain constants.Chain, contractAddress string) (resp types.TokenPrice, err error)
-	GetGainers(chain constants.Chain) (resp types.TokenDetailsResp, err error)
-	GetLosers(chain constants.Chain) (resp types.TokenDetailsResp, err error)
+	GetTokenPriceAtInstant(chain constants.Chain, contractAddress string, timestamp int64) (types.TokenPrice, error)
+	GetTokenCurrentPrice(chain constants.Chain, contractAddress string) (resp types.TokenPrice, err error)
+	GetTopGainers(chain constants.Chain) (resp types.TokenDetailsResp, err error)
+	GetTopLosers(chain constants.Chain) (resp types.TokenDetailsResp, err error)
 	GetLPTokens(chain constants.Chain, lptoken string) (resp types.TokenListWithPrice, err error)
-	GetTokensPrice(chain constants.Chain, tokenList []string) (resp types.TokenListWithPrice, err error)
-	GetPriceWithSymbol(symbol string) (resp types.PriceWithSymbolResp, err error)
+	GetMultipleTokenPrice(chain constants.Chain, tokenList []string) (resp types.TokenListWithPrice, err error)
+	GetTokenPriceBySymbol(symbol string) (resp types.PriceWithSymbolResp, err error)
 }

--- a/pkg/token_price/token_price_impl.go
+++ b/pkg/token_price/token_price_impl.go
@@ -22,7 +22,7 @@ func New(sess session.Session) PriceStoreImpl {
 //GetPriceAtInstant accepts a chain, contract address and a timestamp.
 //It fetches the price of a token at a given point in time.
 //If the token is not found, expect an empty response with no error.
-func (p PriceStoreImpl) GetPriceAtInstant(chain constants.Chain, contractAddress string, timestamp int64) (resp types.TokenPrice, err error) {
+func (p PriceStoreImpl) GetTokenPriceAtInstant(chain constants.Chain, contractAddress string, timestamp int64) (resp types.TokenPrice, err error) {
 	if !constants.PS_GetTokensPrice.SupportsChain(chain) {
 		return types.TokenPrice{}, constants.UnsupportedChainError
 	}
@@ -38,7 +38,7 @@ func (p PriceStoreImpl) GetPriceAtInstant(chain constants.Chain, contractAddress
 
 //GetCurrentPrice accepts a chain and a contract address. It fetches the token's current price.
 //If the token is not found, expect an empty response with no error.
-func (p PriceStoreImpl) GetCurrentPrice(chain constants.Chain, contractAddress string) (resp types.TokenPrice, err error) {
+func (p PriceStoreImpl) GetTokenCurrentPrice(chain constants.Chain, contractAddress string) (resp types.TokenPrice, err error) {
 	if !constants.PS_GetTokensPrice.SupportsChain(chain) {
 		return types.TokenPrice{}, constants.UnsupportedChainError
 	}
@@ -51,7 +51,7 @@ func (p PriceStoreImpl) GetCurrentPrice(chain constants.Chain, contractAddress s
 }
 
 //GetGainers accepts only the chain and returns a list of top gainers
-func (p PriceStoreImpl) GetGainers(chain constants.Chain) (resp types.TokenDetailsResp, err error) {
+func (p PriceStoreImpl) GetTopGainers(chain constants.Chain) (resp types.TokenDetailsResp, err error) {
 	if !constants.PS_GetGainers.SupportsChain(chain) {
 		return types.TokenDetailsResp{}, constants.UnsupportedChainError
 	}
@@ -63,7 +63,7 @@ func (p PriceStoreImpl) GetGainers(chain constants.Chain) (resp types.TokenDetai
 }
 
 //GetLosers accepts only the chain and returns a list of top losers for that chain
-func (p PriceStoreImpl) GetLosers(chain constants.Chain) (resp types.TokenDetailsResp, err error) {
+func (p PriceStoreImpl) GetTopLosers(chain constants.Chain) (resp types.TokenDetailsResp, err error) {
 	if !constants.PS_GetLosers.SupportsChain(chain) {
 		return types.TokenDetailsResp{}, constants.UnsupportedChainError
 	}
@@ -91,7 +91,7 @@ func (p PriceStoreImpl) GetLPTokens(chain constants.Chain, lptoken string) (resp
 }
 
 //GetTokensPrice takes in a chain and a list of tokens. It then returns the price for all specified tokens in the list
-func (p PriceStoreImpl) GetTokensPrice(chain constants.Chain, tokenList []string) (resp types.TokenListWithPrice, err error) {
+func (p PriceStoreImpl) GetMultipleTokenPrice(chain constants.Chain, tokenList []string) (resp types.TokenListWithPrice, err error) {
 	if !constants.PS_GetTokensPrice.SupportsChain(chain) {
 		return types.TokenListWithPrice{}, constants.UnsupportedChainError
 	}
@@ -106,7 +106,7 @@ func (p PriceStoreImpl) GetTokensPrice(chain constants.Chain, tokenList []string
 
 //GetPriceWithSymbol accepts a Symbol and returns an array of token with their prices that match the symbol
 //If the token is not found, expect an empty response with no error.
-func (p PriceStoreImpl) GetPriceWithSymbol(symbol string) (resp types.PriceWithSymbolResp, err error) {
+func (p PriceStoreImpl) GetTokenPriceBySymbol(symbol string) (resp types.PriceWithSymbolResp, err error) {
 	path := strings.Replace(constants.PS_GetPriceWithSymbol.GetURI(), ":symbol", symbol, 1)
 	var urlVals = make(url.Values)
 	err = p.sess.Client.Get(&resp, path, urlVals)

--- a/pkg/token_price/token_price_impl_test.go
+++ b/pkg/token_price/token_price_impl_test.go
@@ -19,30 +19,30 @@ func TestPriceStoreV1_GetPrice(t1 *testing.T) {
 	var time int64 = 1600173203
 
 	t1.Run("Evaluate Get Price at instant", func(t *testing.T) {
-		resp, err := ps.GetPriceAtInstant(chain, validAddr, time)
+		resp, err := ps.GetTokenPriceAtInstant(chain, validAddr, time)
 
 		ast.NoError(err, "There should be no error for a valid call")
 		ast.NotEmpty(resp, "The response should not be empty")
 
-		resp, _ = ps.GetPriceAtInstant(chain, "invalidAddr", time)
+		resp, _ = ps.GetTokenPriceAtInstant(chain, "invalidAddr", time)
 		ast.Empty(resp, "should have an empty response for an invalid call")
 
 		//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
-		_, err = ps.GetPriceAtInstant(constants.HUOBI, "", 0)
+		_, err = ps.GetTokenPriceAtInstant(constants.HUOBI, "", 0)
 		ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
 	})
 
 	t1.Run("Evaluate Get  Current Price", func(t *testing.T) {
-		resp, err := ps.GetCurrentPrice(chain, validAddr)
+		resp, err := ps.GetTokenCurrentPrice(chain, validAddr)
 
 		ast.NoError(err, "There should be no error for a valid call")
 		ast.NotEmpty(resp, "The response should not be empty")
 
-		resp, _ = ps.GetCurrentPrice(chain, "invalidAddr")
+		resp, _ = ps.GetTokenCurrentPrice(chain, "invalidAddr")
 		ast.Empty(resp, "should have an empty response for an invalid call")
 
 		//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
-		_, err = ps.GetCurrentPrice(constants.HUOBI, "")
+		_, err = ps.GetTokenCurrentPrice(constants.HUOBI, "")
 		ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
 	})
 
@@ -86,12 +86,12 @@ func TestPriceStoreV1_GetTokensPrice(t *testing.T) {
 	validAddr := []string{"0x2fa5daf6fe0708fbd63b1a7d1592577284f52256", "0xad29abb318791d579433d831ed122afeaf29dcfe"}
 	chain := constants.BSC
 	t.Run("Evaluate PS_GetTokensPrice", func(t *testing.T) {
-		resp, err := ps.GetTokensPrice(chain, validAddr)
+		resp, err := ps.GetMultipleTokenPrice(chain, validAddr)
 
 		ast.NoError(err, "There should be no error for a valid call")
 		ast.NotEmpty(resp, "The response should not be empty")
 
-		resp, _ = ps.GetTokensPrice(chain, nil)
+		resp, _ = ps.GetMultipleTokenPrice(chain, nil)
 		ast.Empty(resp, "should have an empty response for an invalid call")
 	})
 }
@@ -100,13 +100,13 @@ func TestPriceStoreV1_GetPriceWithSymbol(t *testing.T) {
 	ps := getTestPriceStore()
 	ast := assert.New(t)
 	symbol := "marsh"
-	t.Run("Evaluate GetPriceWithSymbol", func(t *testing.T) {
-		resp, err := ps.GetPriceWithSymbol(symbol)
+	t.Run("Evaluate GetTokenPriceBySymbol", func(t *testing.T) {
+		resp, err := ps.GetTokenPriceBySymbol(symbol)
 
 		ast.NoError(err, "There should be no error for a valid call")
 		ast.NotEmpty(resp, "The response should not be empty")
 
-		resp, _ = ps.GetPriceWithSymbol("")
+		resp, _ = ps.GetTokenPriceBySymbol("")
 		ast.Empty(resp, "should have an empty response for an invalid call")
 	})
 }
@@ -115,13 +115,13 @@ func TestPriceStoreV1_GetLosers(t *testing.T) {
 	ps := getTestPriceStore()
 	ast := assert.New(t)
 	chain := constants.ETH
-	resp, err := ps.GetLosers(chain)
+	resp, err := ps.GetTopLosers(chain)
 
 	ast.NoError(err, "There should be no error for a valid call")
 	ast.NotEmpty(resp, "The response should not be empty")
 
 	//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
-	_, err = ps.GetLosers(constants.HUOBI)
+	_, err = ps.GetTopLosers(constants.HUOBI)
 	ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
 }
 
@@ -129,12 +129,12 @@ func TestPriceStoreV1_GetGainers(t *testing.T) {
 	ps := getTestPriceStore()
 	ast := assert.New(t)
 	chain := constants.ETH
-	resp, err := ps.GetGainers(chain)
+	resp, err := ps.GetTopGainers(chain)
 
 	ast.NoError(err, "There should be no error for a valid call")
 	ast.NotEmpty(resp, "The response should not be empty")
 
 	//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
-	_, err = ps.GetGainers(constants.HUOBI)
+	_, err = ps.GetTopGainers(constants.HUOBI)
 	ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
 }

--- a/pkg/unmarshal.go
+++ b/pkg/unmarshal.go
@@ -5,6 +5,7 @@ import (
 	conf "github.com/eucrypt/unmarshal-go-sdk/pkg/config"
 	httpclient "github.com/eucrypt/unmarshal-go-sdk/pkg/http"
 	"github.com/eucrypt/unmarshal-go-sdk/pkg/nft_details"
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/protocol_details"
 	"github.com/eucrypt/unmarshal-go-sdk/pkg/session"
 	"github.com/eucrypt/unmarshal-go-sdk/pkg/token_details"
 	"github.com/eucrypt/unmarshal-go-sdk/pkg/token_price"
@@ -17,6 +18,7 @@ type Unmarshal struct {
 	assets.Assets
 	nft_details.NftDetails
 	transaction_details.TransactionDetails
+	protocol_details.ProtocolDetails
 }
 
 func NewWithConfig(config conf.Config) Unmarshal {
@@ -33,6 +35,7 @@ func NewWithConfig(config conf.Config) Unmarshal {
 		Assets:             assets.New(sess),
 		NftDetails:         nft_details.New(sess),
 		TransactionDetails: transaction_details.New(sess),
+		ProtocolDetails:    protocol_details.New(sess),
 	}
 }
 
@@ -45,5 +48,6 @@ func NewWithOptions(authKey string, options ...conf.ConfigOptions) Unmarshal {
 		Assets:             assets.New(sess),
 		NftDetails:         nft_details.New(sess),
 		TransactionDetails: transaction_details.New(sess),
+		ProtocolDetails:    protocol_details.New(sess),
 	}
 }


### PR DESCRIPTION
This commit adds support for the [Protocol APIs](https://docs.unmarshal.io/unmarshal-protocol-apis)

It supports:
- `/v2/protocols/:protocol/pairs` --> `GetPairs()`
- `/v2/protocols/:protocol/address/:address/positions` --> `GetPositions()`