### PR TITLE
Adding Profit and Loss/User Data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,23 @@ The first step involved is to `go get` this project.
 go get github.com/eucrypt/unmarshal-go-sdk
 ```
 
-Create an SDK type and pass it your auth key. (To generate an Auth key you will need to create a user account at [Unmarshal Console](
-console.unmarshal.io))
+Create an SDK type and pass it your auth key. (To generate an Auth key you will need to create a user account
+at [Unmarshal Console](console.unmarshal.io))
 
 ```go
 package main
 
 import (
-  unmarshal "github.com/eucrypt/unmarshal-go-sdk/pkg"
-  conf "github.com/eucrypt/unmarshal-go-sdk/pkg/config"
-  "github.com/eucrypt/unmarshal-go-sdk/pkg/constants"
+	unmarshal "github.com/eucrypt/unmarshal-go-sdk/pkg"
+	conf "github.com/eucrypt/unmarshal-go-sdk/pkg/config"
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/constants"
 )
 
 func main() {
-  sdk := unmarshal.NewWithConfig(conf.Config{
-    AuthKey:     "<auth key>",
-    Environment: constants.Prod,
-  })
+	sdk := unmarshal.NewWithConfig(conf.Config{
+		AuthKey:     "<auth key>",
+		Environment: constants.Prod,
+	})
 }
 ```
 
@@ -40,18 +40,18 @@ unmarshal APIs
 package main
 
 import (
-  unmarshal "github.com/eucrypt/unmarshal-go-sdk/pkg"
-  conf "github.com/eucrypt/unmarshal-go-sdk/pkg/config"
-  "github.com/eucrypt/unmarshal-go-sdk/pkg/constants"
+	unmarshal "github.com/eucrypt/unmarshal-go-sdk/pkg"
+	conf "github.com/eucrypt/unmarshal-go-sdk/pkg/config"
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/constants"
 )
 
 func main() {
-  sdk := unmarshal.NewWithConfig(conf.Config{
-    AuthKey:     "<auth key>",
-    Environment: constants.Prod,
-  })
+	sdk := unmarshal.NewWithConfig(conf.Config{
+		AuthKey:     "<auth key>",
+		Environment: constants.Prod,
+	})
 
-  resp, err := sdk.GetTokenPriceBySymbol("marsh")
+	resp, err := sdk.GetTokenPriceBySymbol("marsh")
 }
 
 ```
@@ -62,18 +62,18 @@ Some functions are chain specific and the chain can be passed in via the `consta
 package main
 
 import (
-  unmarshal "github.com/eucrypt/unmarshal-go-sdk/pkg"
-  conf "github.com/eucrypt/unmarshal-go-sdk/pkg/config"
-  "github.com/eucrypt/unmarshal-go-sdk/pkg/constants"
+	unmarshal "github.com/eucrypt/unmarshal-go-sdk/pkg"
+	conf "github.com/eucrypt/unmarshal-go-sdk/pkg/config"
+	"github.com/eucrypt/unmarshal-go-sdk/pkg/constants"
 )
 
 func main() {
-  sdk := unmarshal.NewWithConfig(conf.Config{
-    AuthKey:     "<auth key>",
-    Environment: constants.Prod,
-  })
+	sdk := unmarshal.NewWithConfig(conf.Config{
+		AuthKey:     "<auth key>",
+		Environment: constants.Prod,
+	})
 
-  resp, err := sdk.GetTokenCurrentPrice(constants.BSC, "0x2fa5daf6fe0708fbd63b1a7d1592577284f52256")
+	resp, err := sdk.GetTokenCurrentPrice(constants.BSC, "0x2fa5daf6fe0708fbd63b1a7d1592577284f52256")
 }
 
 ```
@@ -83,59 +83,61 @@ func main() {
 ### Price Store ([Docs](https://docs.unmarshal.io/openapi/core/tag/Price-Store/))
 
 - Get Price
-  - `v1/pricestore/chain/:chain/:address` (`GetTokenCurrentPrice`)
+    - `v1/pricestore/chain/:chain/:address` (`GetTokenCurrentPrice`)
 - Get Price at Instant
-  - `v1/pricestore/chain/:chain/:address?timestamp=` (`GetTokenPriceAtInstant`)
+    - `v1/pricestore/chain/:chain/:address?timestamp=` (`GetTokenPriceAtInstant`)
 - Get Price With Symbol
-  - `v1/pricestore/:symbol` (`GetTokenPriceBySymbol`)
+    - `v1/pricestore/:symbol` (`GetTokenPriceBySymbol`)
 - Get Gainers
-  - `v1/pricestore/chain/:chain/gainers` (`GetTopGainers`)
+    - `v1/pricestore/chain/:chain/gainers` (`GetTopGainers`)
 - Get Losers
-  - `v1/pricestore/chain/:chain/losers` (`GetTopLosers`)
+    - `v1/pricestore/chain/:chain/losers` (`GetTopLosers`)
 - Get LpTokens
-  - `v1/pricestore/chain/:chain/lptokens` (`GetLPTokens`)
+    - `v1/pricestore/chain/:chain/lptokens` (`GetLPTokens`)
 - Get Price of List of tokens
-  - `v1/tokenstore/token/all` (`GetMultipleTokenPrice`)
+    - `v1/tokenstore/token/all` (`GetMultipleTokenPrice`)
 
 ### Token Details ([Docs](https://docs.unmarshal.io/openapi/core/tag/Token-Store/))
 
 - Get Token With Contract
-  - `v1/tokenstore/token/address/:address` (`GetTokenDetailsByContract`)
+    - `v1/tokenstore/token/address/:address` (`GetTokenDetailsByContract`)
 - Get Token With Symbol
-  - `v1/tokenstore/token/symbol/:symbol` (`GetTokenDetailsBySymbol`)
+    - `v1/tokenstore/token/symbol/:symbol` (`GetTokenDetailsBySymbol`)
 - Get Paginated List Of Tokens
-  - `v1/tokenstore/token/all` (`GetTokenList`)
+    - `v1/tokenstore/token/all` (`GetTokenList`)
 
 ### Assets API ([Docs](https://docs.unmarshal.io/openapi/core/tag/Wallet-APIs/))
 
 - Get List of Assets
-  - `v1/:chain/address/:address/assets` (`GetTokenAssets`)
+    - `v1/:chain/address/:address/assets` (`GetTokenAssets`)
+- Get Profit and loss
+    - `v2/:chain/address/:address/userData?contract=` (`GetProfitAndLoss`)
 
 ### NFT APIs ([Docs](https://docs.unmarshal.io/openapi/core/tag/NFTs/))
 
 - Get NFT assets for an address
-  - `v1/:chain/address/:address/nft-assets` (`GetNFTAssetsByAddress`)
+    - `v1/:chain/address/:address/nft-assets` (`GetNFTAssetsByAddress`)
 - Get NFT Transactions by Address
-  - `v1/:chain/address/:address/nft-transactions` (`GetNFTTransactionsByAddress`)
+    - `v1/:chain/address/:address/nft-transactions` (`GetNFTTransactionsByAddress`)
 - Get NFT Metadata
-  - `v1/:chain/address/:address/details?tokenId=` (`GetNFTDetailsByID`)
+    - `v1/:chain/address/:address/details?tokenId=` (`GetNFTDetailsByID`)
 - Get NFT Holders using the NFT's Token ID
-  - `v1/:chain/address/:address/nftholders?tokenId=` (`GetNFTHolderByID`)
+    - `v1/:chain/address/:address/nftholders?tokenId=` (`GetNFTHolderByID`)
 
 ### Transaction APIs ([Docs](https://docs.unmarshal.io/openapi/core/tag/Wallet-APIs/#tag/Wallet-APIs/operation/transaction-history-v-1))
 
 - Get Transaction data for an address
-  - `v1/:chain/address/:address/transactions?contract=&page=&pageSize=` (`GetTokenTxns`)
+    - `v1/:chain/address/:address/transactions?contract=&page=&pageSize=` (`GetTokenTxns`)
 - Get Transactions data for an address V2/Get Transactions with Price data
-  - `v2/:chain/address/:address/transactions?contract=&page=&pageSize=` (`GetTokenTxnsV2`)
+    - `v2/:chain/address/:address/transactions?contract=&page=&pageSize=` (`GetTokenTxnsV2`)
 - Get Transaction details by Transaction ID
-  - `v1/:chain/transactions/:txID` (`GetTxnDetails`)
+    - `v1/:chain/transactions/:txID` (`GetTxnDetails`)
 
 ### Protocol APIs ([Docs](https://docs.unmarshal.io/openapi/core/tag/Price-Store/#tag/Price-Store/operation/price-for-lp-tokens))
 
 - Get Protocol Positions for an address
-  - `v2/protocols/:protocol/address/:address/positions` (`GetPositions`)
+    - `v2/protocols/:protocol/address/:address/positions` (`GetPositions`)
 - Get Protocol Pairs
-  - `v2/protocols/:protocol/pairs` (`GetPairs`)
+    - `v2/protocols/:protocol/pairs` (`GetPairs`)
 
 

--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -7,4 +7,5 @@ import (
 
 type Assets interface {
 	GetTokenAssets(chain constants.Chain, address string) (response types.AssetDetailsV1Resp, err error)
+	GetProfitAndLoss(chain constants.Chain, address, contract string) (response types.UserContractData, err error)
 }

--- a/pkg/assets/assets_store_impl.go
+++ b/pkg/assets/assets_store_impl.go
@@ -1,14 +1,32 @@
 package assets
 
 import (
+	"fmt"
 	"github.com/eucrypt/unmarshal-go-sdk/pkg/assets/types"
 	"github.com/eucrypt/unmarshal-go-sdk/pkg/constants"
+	httpclient "github.com/eucrypt/unmarshal-go-sdk/pkg/http"
 	"github.com/eucrypt/unmarshal-go-sdk/pkg/session"
 	"strings"
 )
 
 type V1Store struct {
 	sess session.Session
+}
+
+//GetProfitAndLoss Accepts chain, address and the token contract. It uses this data to return user data that gives the
+//user the profit or loss incurred by the address holder for the particular contract
+func (a V1Store) GetProfitAndLoss(chain constants.Chain, address, contract string) (response types.UserContractData, err error) {
+	if !constants.ASSETS_GetProfitsAndLoss.SupportsChain(chain) {
+		return response, constants.UnsupportedChainError
+	}
+	path := strings.Replace(constants.ASSETS_GetProfitsAndLoss.GetURI(), ":chain", chain.String(), 1)
+	path = strings.Replace(path, ":address", address, 1)
+	vals := map[string]interface{}{
+		"contract": fmt.Sprint(contract),
+	}
+	queryParams := httpclient.QueryParamHelper(vals)
+	err = a.sess.Client.Get(&response, path, queryParams)
+	return
 }
 
 func New(sess session.Session) V1Store {

--- a/pkg/assets/assets_store_impl_test.go
+++ b/pkg/assets/assets_store_impl_test.go
@@ -11,22 +11,44 @@ import (
 )
 
 func TestV1Store_GetAssets(t *testing.T) {
-	ps := getTestPriceStore()
+	testAssetsStore := getTestAssetsStore()
 	ast := assert.New(t)
 	validAddr := "demo.eth"
 	chain := constants.ETH
-	t.Run("Evaluate Get  Current Price", func(t *testing.T) {
-		resp, err := ps.GetTokenAssets(chain, validAddr)
+	t.Run("Evaluate TokenAssets", func(t *testing.T) {
+		resp, err := testAssetsStore.GetTokenAssets(chain, validAddr)
 
 		ast.NoError(err, "There should be no error for a valid call")
 		ast.NotEmpty(resp, "The response should not be empty")
 
-		resp, _ = ps.GetTokenAssets(chain, "invalidAddr")
+		resp, _ = testAssetsStore.GetTokenAssets(chain, "invalidAddr")
 		ast.Empty(resp, "should have an empty response for an invalid call")
 	})
 }
 
-func getTestPriceStore() V1Store {
+func TestV1Store_GetProfitAndLoss(t *testing.T) {
+	assetsStore := getTestAssetsStore()
+	ast := assert.New(t)
+	validAddr := "demo.eth"
+	validContract := "0xdac17f958d2ee523a2206206994597c13d831ec7"
+	chain := constants.ETH
+	t.Run("Evaluate Profit and Loss", func(t *testing.T) {
+		resp, err := assetsStore.GetProfitAndLoss(chain, validAddr, validContract)
+		ast.NoError(err, "There should be no error for a valid call")
+		ast.NotEmpty(resp, "The response should not be empty")
+
+		resp, _ = assetsStore.GetProfitAndLoss(chain, "invalid", validContract)
+		ast.Empty(resp, "should have an empty response for an invalid call")
+		resp, _ = assetsStore.GetProfitAndLoss(chain, validAddr, "invalid")
+		ast.Empty(resp, "should have an empty response for an invalid call")
+
+		//@dev The chain below is currently unsupported. Test will be deprecated if the chain is ever supported
+		_, err = assetsStore.GetProfitAndLoss(constants.HUOBI, "demo.eth", "")
+		ast.Equal(constants.UnsupportedChainError, err, "Call should result in an unsupported chain error")
+	})
+}
+
+func getTestAssetsStore() V1Store {
 	httpClient := httpclient.NewHttpJSONClient(constants.Environment.GetEndpoint("prod"))
 	authKey := os.Getenv("API_KEY")
 	httpClient.DefaultQuery = map[string]string{"auth_key": authKey}

--- a/pkg/assets/types/types.go
+++ b/pkg/assets/types/types.go
@@ -16,3 +16,14 @@ type AssetDetailsV1 struct {
 }
 
 type AssetDetailsV1Resp []AssetDetailsV1
+
+type UserContractData struct {
+	QuoteRate              float64 `json:"quote_rate"`
+	TotalFeesPaid          float64 `json:"total_fees_paid"`
+	TotalFeesPaidUsd       float64 `json:"total_fees_paid_usd"`
+	AverageTokenPrice      float64 `json:"average_token_price"`
+	OverallProfitLoss      float64 `json:"overall_profit_loss"`
+	CurrentHoldingQuantity float64 `json:"current_holding_quantity"`
+	PercentageChange24H    float64 `json:"percentage_change_24H"`
+	PriceChange24H         float64 `json:"price_change_24H"`
+}

--- a/pkg/constants/api_name.go
+++ b/pkg/constants/api_name.go
@@ -3,41 +3,43 @@ package constants
 type APIName string
 
 const (
-	PS_GetPriceWithAddress  APIName = "v1/pricestore/chain/:chain/:address"
-	PS_GetTokensPrice       APIName = "v1/pricestore/chain/:chain/tokens"
-	PS_GetLpTokenPrice      APIName = "v1/pricestore/chain/:chain/lptokens"
-	PS_GetLosers            APIName = "v1/pricestore/chain/:chain/losers"
-	PS_GetGainers           APIName = "v1/pricestore/chain/:chain/gainers"
-	PS_GetPriceBySymbol     APIName = "v1/pricestore/:symbol"
-	TS_GetDetailsByContract APIName = "v1/tokenstore/token/address/:address"
-	TS_GetTokenList         APIName = "v1/tokenstore/token/all"
-	TS_GetTokenBySymbol     APIName = "v1/tokenstore/token/symbol/:symbol"
-	ASSETS_GetTokenAssets   APIName = "v1/:chain/address/:address/assets"
-	NFT_GetNFTAssets        APIName = "v1/:chain/address/:address/nft-assets"
-	NFT_GetTxns             APIName = "v1/:chain/address/:address/nft-transactions"
-	NFT_GetDetailsByID      APIName = "v1/:chain/address/:address/details"
-	NFT_GetHoldersByID      APIName = "v1/:chain/address/:address/nftholders"
-	TXN_GetTokenTxns        APIName = "v1/:chain/address/:address/transactions"
-	TXN_GetTxnDetails       APIName = "v1/:chain/transactions/:txnID"
-	TXN_GetTokenTxnsV2      APIName = "v2/:chain/address/:address/transactions"
-	PROTO_GetPositions      APIName = "v2/protocols/:protocol/address/:address/positions"
-	PROTO_GetPairs          APIName = "v2/protocols/:protocol/pairs"
+	PS_GetPriceWithAddress   APIName = "v1/pricestore/chain/:chain/:address"
+	PS_GetTokensPrice        APIName = "v1/pricestore/chain/:chain/tokens"
+	PS_GetLpTokenPrice       APIName = "v1/pricestore/chain/:chain/lptokens"
+	PS_GetLosers             APIName = "v1/pricestore/chain/:chain/losers"
+	PS_GetGainers            APIName = "v1/pricestore/chain/:chain/gainers"
+	PS_GetPriceBySymbol      APIName = "v1/pricestore/:symbol"
+	TS_GetDetailsByContract  APIName = "v1/tokenstore/token/address/:address"
+	TS_GetTokenList          APIName = "v1/tokenstore/token/all"
+	TS_GetTokenBySymbol      APIName = "v1/tokenstore/token/symbol/:symbol"
+	ASSETS_GetTokenAssets    APIName = "v1/:chain/address/:address/assets"
+	ASSETS_GetProfitsAndLoss APIName = "v2/:chain/address/:address/userData"
+	NFT_GetNFTAssets         APIName = "v1/:chain/address/:address/nft-assets"
+	NFT_GetTxns              APIName = "v1/:chain/address/:address/nft-transactions"
+	NFT_GetDetailsByID       APIName = "v1/:chain/address/:address/details"
+	NFT_GetHoldersByID       APIName = "v1/:chain/address/:address/nftholders"
+	TXN_GetTokenTxns         APIName = "v1/:chain/address/:address/transactions"
+	TXN_GetTxnDetails        APIName = "v1/:chain/transactions/:txnID"
+	TXN_GetTokenTxnsV2       APIName = "v2/:chain/address/:address/transactions"
+	PROTO_GetPositions       APIName = "v2/protocols/:protocol/address/:address/positions"
+	PROTO_GetPairs           APIName = "v2/protocols/:protocol/pairs"
 )
 
 var allowedCallersByChain = map[APIName]map[Chain]bool{
-	PS_GetPriceWithAddress: priceStoreSupported,
-	PS_GetTokensPrice:      priceStoreSupported,
-	PS_GetLpTokenPrice:     priceStoreSupported,
-	PS_GetLosers:           priceStoreSupported,
-	PS_GetGainers:          priceStoreSupported,
-	ASSETS_GetTokenAssets:  allChains,
-	NFT_GetNFTAssets:       {ETH: true, BSC: true, MATIC: true, SOL: true},
-	NFT_GetTxns:            nftEVMSupport,
-	NFT_GetDetailsByID:     nftEVMSupport,
-	NFT_GetHoldersByID:     nftEVMSupport,
-	TXN_GetTokenTxns:       {ETH: true, BSC: true, MATIC: true, SOL: true, ZILLIQA: true, XDC: true},
-	TXN_GetTxnDetails:      {ETH: true, BSC: true, MATIC: true, SOL: true, XDC: true},
-	TXN_GetTokenTxnsV2:     {ETH: true, BSC: true, XDC: true},
+	PS_GetPriceWithAddress:   priceStoreSupported,
+	PS_GetTokensPrice:        priceStoreSupported,
+	PS_GetLpTokenPrice:       priceStoreSupported,
+	PS_GetLosers:             priceStoreSupported,
+	PS_GetGainers:            priceStoreSupported,
+	ASSETS_GetTokenAssets:    allChains,
+	ASSETS_GetProfitsAndLoss: priceStoreSupported,
+	NFT_GetNFTAssets:         {ETH: true, BSC: true, MATIC: true, SOL: true},
+	NFT_GetTxns:              nftEVMSupport,
+	NFT_GetDetailsByID:       nftEVMSupport,
+	NFT_GetHoldersByID:       nftEVMSupport,
+	TXN_GetTokenTxns:         {ETH: true, BSC: true, MATIC: true, SOL: true, ZILLIQA: true, XDC: true},
+	TXN_GetTxnDetails:        {ETH: true, BSC: true, MATIC: true, SOL: true, XDC: true},
+	TXN_GetTokenTxnsV2:       {ETH: true, BSC: true, XDC: true},
 }
 
 //SupportsChain Allows a caller to know if a chain specific API supports a passed valid chain

--- a/pkg/token_price/token_price_impl.go
+++ b/pkg/token_price/token_price_impl.go
@@ -19,7 +19,7 @@ func New(sess session.Session) PriceStoreImpl {
 	return PriceStoreImpl{sess}
 }
 
-//GetPriceAtInstant accepts a chain, contract address and a timestamp.
+// GetTokenPriceAtInstant GetPriceAtInstant accepts a chain, contract address and a timestamp.
 //It fetches the price of a token at a given point in time.
 //If the token is not found, expect an empty response with no error.
 func (p PriceStoreImpl) GetTokenPriceAtInstant(chain constants.Chain, contractAddress string, timestamp int64) (resp types.TokenPrice, err error) {
@@ -36,7 +36,7 @@ func (p PriceStoreImpl) GetTokenPriceAtInstant(chain constants.Chain, contractAd
 	return
 }
 
-//GetCurrentPrice accepts a chain and a contract address. It fetches the token's current price.
+// GetTokenCurrentPrice GetCurrentPrice accepts a chain and a contract address. It fetches the token's current price.
 //If the token is not found, expect an empty response with no error.
 func (p PriceStoreImpl) GetTokenCurrentPrice(chain constants.Chain, contractAddress string) (resp types.TokenPrice, err error) {
 	if !constants.PS_GetTokensPrice.SupportsChain(chain) {


### PR DESCRIPTION
Closes #6 

This PR adds support for the [Profit and Loss API](https://docs.unmarshal.io/openapi/core/tag/Wallet-APIs/#tag/Wallet-APIs/operation/get-profit-and-loss)
