### PR TITLE
Supporting additional query params for Pricestore

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,7 @@ github.com/prometheus/procfs v0.0.0-20190425082905-87a4384529e0 h1:c8R11WC8m7KNM
 github.com/prometheus/procfs v0.0.0-20190425082905-87a4384529e0/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/santhosh-tekuri/jsonschema v1.2.4 h1:hNhW8e7t+H1vgY+1QeEQpveR6D4+OwKPXCfD2aieJis=
 github.com/santhosh-tekuri/jsonschema v1.2.4/go.mod h1:TEAUOeZSmIxTTuHatJzrvARHiuO9LYd+cIxzgEHCQI4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=

--- a/pkg/constants/api_name.go
+++ b/pkg/constants/api_name.go
@@ -2,6 +2,7 @@ package constants
 
 type APIName string
 
+//goland:noinspection GoSnakeCaseUsage
 const (
 	PS_GetPriceWithAddress   APIName = "v1/pricestore/chain/:chain/:address"
 	PS_GetTokensPrice        APIName = "v1/pricestore/chain/:chain/tokens"

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -167,17 +167,18 @@ func GetBody(body interface{}) (buf io.ReadWriter, err error) {
 }
 
 //QueryParamHelper accepts a map of string -> interface and returns the supported url.Values for the map.
-//It will assume any data that is not a []string is instead a string value.
-//This is because, url.Values is compatible only with Strings or string arrays.
 func QueryParamHelper(queryParams map[string]interface{}) (urlVals url.Values) {
 	if queryParams != nil {
 		urlVals = make(url.Values)
 		for key, val := range queryParams {
 			switch val.(type) {
 			default:
-				urlVals.Add(key, val.(string))
+				urlVals.Add(key, fmt.Sprint(val))
 			case []string:
 				urlVals[key] = val.([]string)
+
+			case string:
+				urlVals.Add(key, val.(string))
 			}
 		}
 	}

--- a/pkg/token_price/token_price.go
+++ b/pkg/token_price/token_price.go
@@ -6,11 +6,10 @@ import (
 )
 
 type PriceStore interface {
-	GetTokenPriceAtInstant(chain constants.Chain, contractAddress string, timestamp int64) (types.TokenPrice, error)
-	GetTokenCurrentPrice(chain constants.Chain, contractAddress string) (resp types.TokenPrice, err error)
-	GetTopGainers(chain constants.Chain) (resp types.TokenDetailsResp, err error)
-	GetTopLosers(chain constants.Chain) (resp types.TokenDetailsResp, err error)
+	GetTokenPrice(chain constants.Chain, contractAddress string, options *types.GetPriceOptions) (types.TokenPrice, error)
+	GetTokenPriceBySymbol(symbol string, options *types.GetPriceWithSymbolOptions) (resp types.PriceWithSymbolResp, err error)
+	GetTopGainers(chain constants.Chain, options *types.GetTopGainersOptions) (resp types.TokenDetailsResp, err error)
+	GetTopLosers(chain constants.Chain, options *types.GetTopLosersOptions) (resp types.TokenDetailsResp, err error)
 	GetLPTokens(chain constants.Chain, lptoken string) (resp types.TokenListWithPrice, err error)
 	GetMultipleTokenPrice(chain constants.Chain, tokenList []string) (resp types.TokenListWithPrice, err error)
-	GetTokenPriceBySymbol(symbol string) (resp types.PriceWithSymbolResp, err error)
 }

--- a/pkg/token_price/token_price_impl.go
+++ b/pkg/token_price/token_price_impl.go
@@ -22,53 +22,38 @@ func New(sess session.Session) PriceStoreImpl {
 // GetTokenPriceAtInstant GetPriceAtInstant accepts a chain, contract address and a timestamp.
 //It fetches the price of a token at a given point in time.
 //If the token is not found, expect an empty response with no error.
-func (p PriceStoreImpl) GetTokenPriceAtInstant(chain constants.Chain, contractAddress string, timestamp int64) (resp types.TokenPrice, err error) {
+func (p PriceStoreImpl) GetTokenPrice(chain constants.Chain, contractAddress string, options *types.GetPriceOptions) (resp types.TokenPrice, err error) {
+	fmt.Println("Getting token price")
 	if !constants.PS_GetTokensPrice.SupportsChain(chain) {
 		return types.TokenPrice{}, constants.UnsupportedChainError
 	}
 	path := strings.Replace(constants.PS_GetPriceWithAddress.GetURI(), ":chain", chain.String(), 1)
 	path = strings.Replace(path, ":address", contractAddress, 1)
-	var queryParams = map[string]interface{}{
-		"timestamp": fmt.Sprint(timestamp),
-	}
-	var urlVals = httpclient.QueryParamHelper(queryParams)
+	var urlVals = p.getTokenPriceParams(options)
+	fmt.Println("Got query params")
 	err = p.sess.Client.Get(&resp, path, urlVals)
-	return
-}
-
-// GetTokenCurrentPrice GetCurrentPrice accepts a chain and a contract address. It fetches the token's current price.
-//If the token is not found, expect an empty response with no error.
-func (p PriceStoreImpl) GetTokenCurrentPrice(chain constants.Chain, contractAddress string) (resp types.TokenPrice, err error) {
-	if !constants.PS_GetTokensPrice.SupportsChain(chain) {
-		return types.TokenPrice{}, constants.UnsupportedChainError
-	}
-	path := strings.Replace(constants.PS_GetPriceWithAddress.GetURI(), ":chain", chain.String(), 1)
-	path = strings.Replace(path, ":address", contractAddress, 1)
-	var urlVals = make(url.Values)
-	err = p.sess.Client.Get(&resp, path, urlVals)
-
 	return
 }
 
 //GetTopGainers accepts only the chain and returns a list of top gainers
-func (p PriceStoreImpl) GetTopGainers(chain constants.Chain) (resp types.TokenDetailsResp, err error) {
+func (p PriceStoreImpl) GetTopGainers(chain constants.Chain, options *types.GetTopGainersOptions) (resp types.TokenDetailsResp, err error) {
 	if !constants.PS_GetGainers.SupportsChain(chain) {
 		return types.TokenDetailsResp{}, constants.UnsupportedChainError
 	}
 	path := strings.Replace(constants.PS_GetGainers.GetURI(), ":chain", chain.String(), 1)
-	var urlVals = make(url.Values)
+	var urlVals = p.getGainersOptions(options)
 	err = p.sess.Client.Get(&resp, path, urlVals)
 
 	return
 }
 
 //GetTopLosers accepts only the chain and returns a list of top losers for that chain
-func (p PriceStoreImpl) GetTopLosers(chain constants.Chain) (resp types.TokenDetailsResp, err error) {
+func (p PriceStoreImpl) GetTopLosers(chain constants.Chain, options *types.GetTopLosersOptions) (resp types.TokenDetailsResp, err error) {
 	if !constants.PS_GetLosers.SupportsChain(chain) {
 		return types.TokenDetailsResp{}, constants.UnsupportedChainError
 	}
 	path := strings.Replace(constants.PS_GetLosers.GetURI(), ":chain", chain.String(), 1)
-	var urlVals = make(url.Values)
+	var urlVals = p.getLosersOptions(options)
 	err = p.sess.Client.Get(&resp, path, urlVals)
 
 	return
@@ -106,10 +91,55 @@ func (p PriceStoreImpl) GetMultipleTokenPrice(chain constants.Chain, tokenList [
 
 //GetTokenPriceBySymbol accepts a Symbol and returns an array of token with their prices that match the symbol
 //If the token is not found, expect an empty response with no error.
-func (p PriceStoreImpl) GetTokenPriceBySymbol(symbol string) (resp types.PriceWithSymbolResp, err error) {
+func (p PriceStoreImpl) GetTokenPriceBySymbol(symbol string, options *types.GetPriceWithSymbolOptions) (resp types.PriceWithSymbolResp, err error) {
 	path := strings.Replace(constants.PS_GetPriceBySymbol.GetURI(), ":symbol", symbol, 1)
-	var urlVals = make(url.Values)
+	var urlVals = p.getTokenPriceBySymbolParams(options)
 	err = p.sess.Client.Get(&resp, path, urlVals)
 
 	return
+}
+
+func (p PriceStoreImpl) getTokenPriceParams(options *types.GetPriceOptions) url.Values {
+	if options == nil {
+		return make(url.Values)
+	}
+	var queryStrings = make(map[string]interface{})
+	if options.Timestamp != 0 {
+		queryStrings["timestamp"] = options.Timestamp
+	}
+	queryStrings["24hchange"] = options.TwentyFourHourChange
+	queryStrings["alternateChain"] = options.AlternateChain
+
+	return httpclient.QueryParamHelper(queryStrings)
+}
+
+func (p PriceStoreImpl) getGainersOptions(options *types.GetTopGainersOptions) url.Values {
+	if options == nil {
+		return make(url.Values)
+	}
+	var queryStrings = make(map[string]interface{})
+
+	queryStrings["price"] = options.MinimumPrice
+	return httpclient.QueryParamHelper(queryStrings)
+}
+
+func (p PriceStoreImpl) getLosersOptions(options *types.GetTopLosersOptions) url.Values {
+	if options == nil {
+		return make(url.Values)
+	}
+	var queryStrings = make(map[string]interface{})
+
+	queryStrings["price"] = options.MinimumPrice
+	return httpclient.QueryParamHelper(queryStrings)
+}
+
+func (p PriceStoreImpl) getTokenPriceBySymbolParams(options *types.GetPriceWithSymbolOptions) url.Values {
+	if options == nil {
+		return make(url.Values)
+	}
+	var queryStrings = make(map[string]interface{})
+	if options.Timestamp != 0 {
+		queryStrings["timestamp"] = options.Timestamp
+	}
+	return httpclient.QueryParamHelper(queryStrings)
 }

--- a/pkg/token_price/token_price_impl.go
+++ b/pkg/token_price/token_price_impl.go
@@ -1,7 +1,6 @@
 package token_price
 
 import (
-	"fmt"
 	"github.com/eucrypt/unmarshal-go-sdk/pkg/constants"
 	httpclient "github.com/eucrypt/unmarshal-go-sdk/pkg/http"
 	"github.com/eucrypt/unmarshal-go-sdk/pkg/session"
@@ -19,18 +18,14 @@ func New(sess session.Session) PriceStoreImpl {
 	return PriceStoreImpl{sess}
 }
 
-// GetTokenPriceAtInstant GetPriceAtInstant accepts a chain, contract address and a timestamp.
-//It fetches the price of a token at a given point in time.
-//If the token is not found, expect an empty response with no error.
+// GetTokenPriceAtInstant GetPriceAtInstant accepts a chain, contract address and additional options.
 func (p PriceStoreImpl) GetTokenPrice(chain constants.Chain, contractAddress string, options *types.GetPriceOptions) (resp types.TokenPrice, err error) {
-	fmt.Println("Getting token price")
 	if !constants.PS_GetTokensPrice.SupportsChain(chain) {
 		return types.TokenPrice{}, constants.UnsupportedChainError
 	}
 	path := strings.Replace(constants.PS_GetPriceWithAddress.GetURI(), ":chain", chain.String(), 1)
 	path = strings.Replace(path, ":address", contractAddress, 1)
 	var urlVals = p.getTokenPriceParams(options)
-	fmt.Println("Got query params")
 	err = p.sess.Client.Get(&resp, path, urlVals)
 	return
 }

--- a/pkg/token_price/types/types.go
+++ b/pkg/token_price/types/types.go
@@ -41,3 +41,21 @@ type PriceFromSymbol struct {
 }
 
 type PriceWithSymbolResp []PriceFromSymbol
+
+type GetPriceOptions struct {
+	Timestamp            uint64
+	TwentyFourHourChange bool
+	AlternateChain       bool
+}
+
+type GetPriceWithSymbolOptions struct {
+	Timestamp uint64
+}
+
+type GetTopGainersOptions struct {
+	MinimumPrice uint64
+}
+
+type GetTopLosersOptions struct {
+	MinimumPrice uint64
+}

--- a/pkg/token_price/types/types.go
+++ b/pkg/token_price/types/types.go
@@ -1,9 +1,10 @@
 package types
 
 type TokenPrice struct {
-	TokenId   string `json:"tokenId"`
-	Timestamp string `json:"timestamp"`
-	Price     string `json:"price"`
+	TokenId     string `json:"tokenId"`
+	Timestamp   string `json:"timestamp"`
+	Price       string `json:"price"`
+	PriceChange string `json:"price_change,omitempty"`
 }
 type TokenDetailsWithPrice struct {
 	Name          string `json:"name"`


### PR DESCRIPTION
The supported price store calls now include a mechanism to pass query params as a pointer.