### PR TITLE
Support for Arbitrum

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,4 +333,4 @@ func main() {
 Additionally, support for raw transaction details include:
 
 `GetRawTransactionsForAddress` : `Ethereum: Mainnet`, `Ethereum: Rinkeby`, `BSC`, `BSC: Testnet`, `Polygon`,
-`Polygon: Mumbai`, `Avalanche: Mainnet`
+`Polygon: Mumbai`, `Avalanche: Mainnet`, `Arbitrum: Mainnet`

--- a/README.md
+++ b/README.md
@@ -154,11 +154,13 @@ func main() {
       <th>XDC</th>
       <th>Zilliqa</th>
       <th>Huobi</th>
+      <th>Arbitrum</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>GetTokenAssets</td>
+      <td>✅</td>
       <td>✅</td>
       <td>✅</td>
       <td>✅</td>
@@ -178,6 +180,7 @@ func main() {
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
+      <td>❌</td>
     </tr>
     <tr>
       <td>GetTokenTxns</td>
@@ -189,6 +192,7 @@ func main() {
       <td>✅</td>
       <td>✅</td>
       <td>❌</td>
+      <td>✅</td>
     </tr>
     <tr>
       <td>GetTxnDetails</td>
@@ -200,6 +204,7 @@ func main() {
       <td>✅</td>
       <td>❌</td>
       <td>❌</td>
+      <td>✅</td>
     </tr>
     <tr>
       <td>GetTxnDetailsV2</td>
@@ -211,6 +216,7 @@ func main() {
       <td>✅</td>
       <td>❌</td>
       <td>❌</td>
+      <td>✅</td>
     </tr>
     <tr>
       <td>GetNFTAssets</td>
@@ -222,6 +228,7 @@ func main() {
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
+      <td>❌</td>
     </tr>
     <tr>
       <td>GetTxns - NFT</td>
@@ -229,6 +236,7 @@ func main() {
       <td>✅</td>
       <td>✅</td>
       <td>✅</td>
+      <td>❌</td>
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
@@ -244,6 +252,7 @@ func main() {
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
+      <td>❌</td>
     </tr>
     <tr>
       <td>GetHoldersByID</td>
@@ -251,6 +260,7 @@ func main() {
       <td>✅</td>
       <td>✅</td>
       <td>✅</td>
+      <td>❌</td>
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
@@ -266,6 +276,7 @@ func main() {
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
+      <td>❌</td>
     </tr> 
     <tr>
       <td>GetTokensPrice</td>
@@ -273,6 +284,7 @@ func main() {
       <td>✅</td>
       <td>✅</td>
       <td>✅</td>
+      <td>❌</td>
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
@@ -288,12 +300,14 @@ func main() {
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
+      <td>❌</td>
     </tr>
     <tr>
       <td>GetLosers</td>
       <td>✅</td>
       <td>✅</td>
       <td>✅</td>
+      <td>❌</td>
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
@@ -310,11 +324,13 @@ func main() {
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
+      <td>❌</td>
     </tr>
+
   </tbody>
 </table>
 
 Additionally, support for raw transaction details include:
 
-`GetRawTransactionsForAddress` : `Ethereum: Mainnet`, `Ethereum: Rinkeby`, `BSC`, `BSC: Testnet`, `Polygon`, 
-                                  `Polygon: Mumbai`, `Avalanche: Mainnet`
+`GetRawTransactionsForAddress` : `Ethereum: Mainnet`, `Ethereum: Rinkeby`, `BSC`, `BSC: Testnet`, `Polygon`,
+`Polygon: Mumbai`, `Avalanche: Mainnet`

--- a/pkg/constants/api_name.go
+++ b/pkg/constants/api_name.go
@@ -39,9 +39,9 @@ var allowedCallersByChain = map[APIName]map[Chain]bool{
 	NFT_GetTxns:                  nftEVMSupport,
 	NFT_GetDetailsByID:           nftEVMSupport,
 	NFT_GetHoldersByID:           nftEVMSupport,
-	TXN_GetTokenTxns:             {ETH: true, BSC: true, MATIC: true, SOL: true, ZILLIQA: true, AVALANCHE: true, XDC: true, OPTIMISM: true},
-	TXN_GetTxnDetails:            {ETH: true, BSC: true, MATIC: true, SOL: true, AVALANCHE: true, XDC: true, OPTIMISM: true},
-	TXN_GetTokenTxnsV2:           {ETH: true, BSC: true, MATIC: true, AVALANCHE: true, XDC: true, OPTIMISM: true},
+	TXN_GetTokenTxns:             {ETH: true, BSC: true, MATIC: true, SOL: true, ZILLIQA: true, AVALANCHE: true, XDC: true, OPTIMISM: true, ARBITRUM: true},
+	TXN_GetTxnDetails:            {ETH: true, BSC: true, MATIC: true, SOL: true, AVALANCHE: true, XDC: true, OPTIMISM: true, ARBITRUM: true},
+	TXN_GetTokenTxnsV2:           {ETH: true, BSC: true, MATIC: true, AVALANCHE: true, XDC: true, OPTIMISM: true, ARBITRUM: true},
 	TXN_GetRawTransactionDetails: rawTxnSupported,
 }
 

--- a/pkg/constants/chain.go
+++ b/pkg/constants/chain.go
@@ -20,6 +20,7 @@ const (
 	HUOBI         Chain = "heco"
 	AVALANCHE     Chain = "avalanche"
 	OPTIMISM      Chain = "optimism"
+	ARBITRUM      Chain = "arbitrum"
 )
 
 //This should be manually changed when a new chain starts being supported
@@ -33,11 +34,12 @@ var allChains = map[Chain]bool{
 	HUOBI:     true,
 	AVALANCHE: true,
 	OPTIMISM:  true,
+	ARBITRUM:  true,
 }
 
 var priceStoreSupported = map[Chain]bool{ETH: true, BSC: true, MATIC: true}
 
-var rawTxnSupported = map[Chain]bool{ETH: true, ETH_RINKEBY: true, BSC: true, BSC_TESTNET: true, MATIC: true, MATIC_TESTNET: true, OPTIMISM: true, AVALANCHE: true}
+var rawTxnSupported = map[Chain]bool{ETH: true, ETH_RINKEBY: true, BSC: true, BSC_TESTNET: true, MATIC: true, MATIC_TESTNET: true, OPTIMISM: true, AVALANCHE: true, ARBITRUM: true}
 
 var nftEVMSupport = map[Chain]bool{ETH: true, BSC: true, MATIC: true, AVALANCHE: true}
 


### PR DESCRIPTION
This PR adds support for the Arbiturm chain. It's referenced by a similarly named constant and supports all calls except for NFT and Price store specific requests