### PR TITLE
Addition of Support for Celo and Fantom

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,15 @@ func main() {
       <th>Zilliqa</th>
       <th>Huobi</th>
       <th>Arbitrum</th>
+      <th>Celo</th>
+      <th>Fantom</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>GetTokenAssets</td>
+      <td>✅</td>
+      <td>✅</td>
       <td>✅</td>
       <td>✅</td>
       <td>✅</td>
@@ -181,6 +185,8 @@ func main() {
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
+      <td>❌</td>
+      <td>❌</td>
     </tr>
     <tr>
       <td>GetTokenTxns</td>
@@ -192,6 +198,8 @@ func main() {
       <td>✅</td>
       <td>✅</td>
       <td>❌</td>
+      <td>✅</td>
+      <td>✅</td>
       <td>✅</td>
     </tr>
     <tr>
@@ -205,6 +213,8 @@ func main() {
       <td>❌</td>
       <td>❌</td>
       <td>✅</td>
+      <td>✅</td>
+      <td>✅</td>
     </tr>
     <tr>
       <td>GetTxnDetailsV2</td>
@@ -216,6 +226,8 @@ func main() {
       <td>✅</td>
       <td>❌</td>
       <td>❌</td>
+      <td>✅</td>
+      <td>✅</td>
       <td>✅</td>
     </tr>
     <tr>
@@ -229,6 +241,8 @@ func main() {
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
+      <td>❌</td>
+      <td>❌</td>
     </tr>
     <tr>
       <td>GetTxns - NFT</td>
@@ -236,6 +250,8 @@ func main() {
       <td>✅</td>
       <td>✅</td>
       <td>✅</td>
+      <td>❌</td>
+      <td>❌</td>
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
@@ -253,6 +269,8 @@ func main() {
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
+      <td>❌</td>
+      <td>❌</td>
     </tr>
     <tr>
       <td>GetHoldersByID</td>
@@ -260,6 +278,8 @@ func main() {
       <td>✅</td>
       <td>✅</td>
       <td>✅</td>
+      <td>❌</td>
+      <td>❌</td>
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
@@ -277,6 +297,8 @@ func main() {
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
+      <td>❌</td>
+      <td>❌</td>
     </tr> 
     <tr>
       <td>GetTokensPrice</td>
@@ -284,6 +306,8 @@ func main() {
       <td>✅</td>
       <td>✅</td>
       <td>✅</td>
+      <td>❌</td>
+      <td>❌</td>
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
@@ -301,6 +325,8 @@ func main() {
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
+      <td>❌</td>
+      <td>❌</td>
     </tr>
     <tr>
       <td>GetLosers</td>
@@ -313,12 +339,16 @@ func main() {
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>
+      <td>❌</td>
+      <td>❌</td>
     </tr>
     <tr>
       <td>GetGainers</td>
       <td>✅</td>
       <td>✅</td>
       <td>✅</td>
+      <td>❌</td>
+      <td>❌</td>
       <td>❌</td>
       <td>❌</td>
       <td>❌</td>

--- a/pkg/constants/api_name.go
+++ b/pkg/constants/api_name.go
@@ -39,9 +39,9 @@ var allowedCallersByChain = map[APIName]map[Chain]bool{
 	NFT_GetTxns:                  nftEVMSupport,
 	NFT_GetDetailsByID:           nftEVMSupport,
 	NFT_GetHoldersByID:           nftEVMSupport,
-	TXN_GetTokenTxns:             {ETH: true, BSC: true, MATIC: true, SOL: true, ZILLIQA: true, AVALANCHE: true, XDC: true, OPTIMISM: true, ARBITRUM: true},
-	TXN_GetTxnDetails:            {ETH: true, BSC: true, MATIC: true, SOL: true, AVALANCHE: true, XDC: true, OPTIMISM: true, ARBITRUM: true},
-	TXN_GetTokenTxnsV2:           {ETH: true, BSC: true, MATIC: true, AVALANCHE: true, XDC: true, OPTIMISM: true, ARBITRUM: true},
+	TXN_GetTokenTxns:             {ETH: true, BSC: true, MATIC: true, SOL: true, ZILLIQA: true, AVALANCHE: true, XDC: true, OPTIMISM: true, ARBITRUM: true, CELO: true, FANTOM: true},
+	TXN_GetTxnDetails:            {ETH: true, BSC: true, MATIC: true, SOL: true, AVALANCHE: true, XDC: true, OPTIMISM: true, ARBITRUM: true, CELO: true, FANTOM: true},
+	TXN_GetTokenTxnsV2:           {ETH: true, BSC: true, MATIC: true, AVALANCHE: true, XDC: true, OPTIMISM: true, ARBITRUM: true, CELO: true, FANTOM: true},
 	TXN_GetRawTransactionDetails: rawTxnSupported,
 }
 

--- a/pkg/constants/chain.go
+++ b/pkg/constants/chain.go
@@ -21,6 +21,8 @@ const (
 	AVALANCHE     Chain = "avalanche"
 	OPTIMISM      Chain = "optimism"
 	ARBITRUM      Chain = "arbitrum"
+	CELO          Chain = "celo"
+	FANTOM        Chain = "fantom"
 )
 
 //This should be manually changed when a new chain starts being supported

--- a/pkg/constants/chain.go
+++ b/pkg/constants/chain.go
@@ -37,11 +37,14 @@ var allChains = map[Chain]bool{
 	AVALANCHE: true,
 	OPTIMISM:  true,
 	ARBITRUM:  true,
+	CELO:      true,
+	FANTOM:    true,
 }
 
 var priceStoreSupported = map[Chain]bool{ETH: true, BSC: true, MATIC: true}
 
-var rawTxnSupported = map[Chain]bool{ETH: true, ETH_RINKEBY: true, BSC: true, BSC_TESTNET: true, MATIC: true, MATIC_TESTNET: true, OPTIMISM: true, AVALANCHE: true, ARBITRUM: true}
+var rawTxnSupported = map[Chain]bool{ETH: true, ETH_RINKEBY: true, BSC: true, BSC_TESTNET: true, MATIC: true,
+	MATIC_TESTNET: true, OPTIMISM: true, AVALANCHE: true, ARBITRUM: true, CELO: true, FANTOM: true}
 
 var nftEVMSupport = map[Chain]bool{ETH: true, BSC: true, MATIC: true, AVALANCHE: true}
 

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -64,7 +64,7 @@ var DefaultErrorHandler = func(res *http.Response, uri string) error {
 }
 
 //GetWithContext makes and HTTP GET call with the provided values after appending the default query values
-//in additon to any existing ones.
+//in addition to any existing ones.
 func (r *Request) GetWithContext(result interface{}, path string, query url.Values, ctx context.Context) error {
 	queryStr := r.safeGetQueryStrWithDefaults(query)
 	uri := strings.Join([]string{r.GetBase(path), queryStr}, "?")


### PR DESCRIPTION
This PR adds support for the `Celo` and `Fantom` chains to the SDK.
Supported calls are common to both chains.

`Assets`, `Transaction Details (Excluding NFT)`, `Raw Transaction Data`